### PR TITLE
ci: rename scope, release config

### DIFF
--- a/apps/react-demo/package.json
+++ b/apps/react-demo/package.json
@@ -5,8 +5,8 @@
     "build": "vite build"
   },
   "dependencies": {
-    "@ks-no/designsystem-react": "workspace:*",
-    "@ks-no/designsystem-themes": "workspace:*",
+    "@ks-utvikling/designsystem-react": "workspace:*",
+    "@ks-utvikling/designsystem-themes": "workspace:*",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },

--- a/apps/react-demo/src/app/app.tsx
+++ b/apps/react-demo/src/app/app.tsx
@@ -1,7 +1,12 @@
-import '@ks-no/designsystem-themes/base.css'
-import '@ks-no/designsystem-themes/ledsagerbevis.css'
+import '@ks-utvikling/designsystem-themes/base.css'
+import '@ks-utvikling/designsystem-themes/ledsagerbevis.css'
 
-import { Alert, Button, Spinner, Heading } from '@ks-no/designsystem-react'
+import {
+  Alert,
+  Button,
+  Spinner,
+  Heading,
+} from '@ks-utvikling/designsystem-react'
 
 export function App() {
   return (

--- a/nx.json
+++ b/nx.json
@@ -1,7 +1,10 @@
 {
   "$schema": "./node_modules/nx/schemas/nx-schema.json",
   "release": {
-    "projects": ["@ks-no/designsystem-themes", "@ks-no/designsystem-react"],
+    "projects": [
+      "@ks-utvikling/designsystem-themes",
+      "@ks-utvikling/designsystem-react"
+    ],
     "projectsRelationship": "fixed",
     "changelog": {
       "workspaceChangelog": {

--- a/nx.json
+++ b/nx.json
@@ -8,7 +8,10 @@
     "projectsRelationship": "fixed",
     "changelog": {
       "workspaceChangelog": {
-        "createRelease": "github"
+        "createRelease": "github",
+        "renderOptions": {
+          "versionTitleDate": false
+        }
       }
     },
     "version": {

--- a/nx.json
+++ b/nx.json
@@ -1,5 +1,17 @@
 {
   "$schema": "./node_modules/nx/schemas/nx-schema.json",
+  "release": {
+    "projects": ["@ks-no/designsystem-themes", "@ks-no/designsystem-react"],
+    "projectsRelationship": "fixed",
+    "changelog": {
+      "workspaceChangelog": {
+        "createRelease": "github"
+      }
+    },
+    "version": {
+      "conventionalCommits": true
+    }
+  },
   "plugins": [
     {
       "plugin": "@nx/eslint/plugin",

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -7,7 +7,7 @@ This library provides React components for KS Digital, designed to align closely
 Install the required packages using your preferred package manager:
 
 ```bash
-pnpm add @ks-no/designsystem-react @ks-no/designsystem-themes
+pnpm add @ks-utvikling/designsystem-react @ks-utvikling/designsystem-themes
 ```
 
 ## Setup
@@ -28,8 +28,8 @@ Add the Inter font to your `index.html`. This API supports the same parameters a
 Import the base styles and the theme you want to use in your application:
 
 ```javascript
-import '@ks-no/designsystem-themes/base.css'
-import '@ks-no/designsystem-themes/ledsagerbevis.css'
+import '@ks-utvikling/designsystem-themes/base.css'
+import '@ks-utvikling/designsystem-themes/ledsagerbevis.css'
 ```
 
 ### 3. Use Components
@@ -37,7 +37,7 @@ import '@ks-no/designsystem-themes/ledsagerbevis.css'
 Import and use the components you need. You can explore the available components at [Designsystemet.no](https://www.designsystemet.no/komponenter):
 
 ```javascript
-import { Button } from '@ks-no/designsystem-react'
+import { Button } from '@ks-utvikling/designsystem-react'
 
 function MyComponent() {
   return <Button data-size="lg">My Button</Button>

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ks-no/designsystem-react",
-  "version": "0.0.0-semantically-released",
+  "version": "0.0.0",
   "license": "MIT",
   "private": true,
   "type": "module",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@ks-no/designsystem-react",
+  "name": "@ks-utvikling/designsystem-react",
   "version": "0.0.0",
   "license": "MIT",
   "private": true,

--- a/packages/react/project.json
+++ b/packages/react/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@ks-no/designsystem-react",
+  "name": "@ks-utvikling/designsystem-react",
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "packages/react/src",
   "projectType": "library",

--- a/packages/react/vite.config.ts
+++ b/packages/react/vite.config.ts
@@ -30,7 +30,7 @@ export default defineConfig(() => ({
     lib: {
       // Could also be a dictionary or array of multiple entry points.
       entry: 'src/index.ts',
-      name: '@ks-no/designsystem-react',
+      name: '@ks-utvikling/designsystem-react',
       fileName: 'index',
       formats: ['es' as const],
     },

--- a/packages/themes/README.md
+++ b/packages/themes/README.md
@@ -19,8 +19,8 @@ To use the themes, include the base styles and one of the supported themes in yo
 If your bundler (e.g., Vite) is configured to resolve npm packages in CSS imports:
 
 ```css
-@import '@ks-no/designsystem-themes/base.css';
-@import '@ks-no/designsystem-themes/ledsagerbevis.css';
+@import '@ks-utvikling/designsystem-themes/base.css';
+@import '@ks-utvikling/designsystem-themes/ledsagerbevis.css';
 ```
 
 ### In JavaScript/TypeScript Files
@@ -28,6 +28,6 @@ If your bundler (e.g., Vite) is configured to resolve npm packages in CSS import
 If you are using a JavaScript or TypeScript application, import the styles like this. If you are using React, please check the readme in the React-package as well.
 
 ```javascript
-import '@ks-no/designsystem-themes/base.css'
-import '@ks-no/designsystem-themes/ledsagerbevis.css'
+import '@ks-utvikling/designsystem-themes/base.css'
+import '@ks-utvikling/designsystem-themes/ledsagerbevis.css'
 ```

--- a/packages/themes/package.json
+++ b/packages/themes/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@ks-no/designsystem-themes",
+  "name": "@ks-utvikling/designsystem-themes",
   "version": "0.0.0",
   "license": "MIT",
   "type": "module",

--- a/packages/themes/package.json
+++ b/packages/themes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ks-no/designsystem-themes",
-  "version": "0.0.0-semantically-released",
+  "version": "0.0.0",
   "license": "MIT",
   "type": "module",
   "exports": {

--- a/packages/themes/project.json
+++ b/packages/themes/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@ks-no/designsystem-themes",
+  "name": "@ks-utvikling/designsystem-themes",
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "packages/themes/src",
   "projectType": "library",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -143,10 +143,10 @@ importers:
 
   apps/react-demo:
     dependencies:
-      '@ks-no/designsystem-react':
+      '@ks-utvikling/designsystem-react':
         specifier: workspace:*
         version: link:../../packages/react
-      '@ks-no/designsystem-themes':
+      '@ks-utvikling/designsystem-themes':
         specifier: workspace:*
         version: link:../../packages/themes
       react:

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -15,8 +15,8 @@
     "skipDefaultLibCheck": true,
     "baseUrl": ".",
     "paths": {
-      "@ks-no/designsystem-react": ["packages/react/src/index.ts"],
-      "@ks-no/designsystem-themes": ["packages/themes/src/index.ts"]
+      "@ks-utvikling/designsystem-react": ["packages/react/src/index.ts"],
+      "@ks-utvikling/designsystem-themes": ["packages/themes/src/index.ts"]
     }
   },
   "exclude": ["node_modules", "tmp", "dist"]


### PR DESCRIPTION
## What is the current behavior?

## What is the new behavior?
The organization on npm has been created as `ks-utvikling`. Renaming the repos scope to align with that.

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) describes this PR best?
