### PR TITLE
feat(themes): introduce tailwind base styles

### DIFF
--- a/packages/themes/README.md
+++ b/packages/themes/README.md
@@ -39,7 +39,7 @@ If you are using Tailwind with [Preflight](https://tailwindcss.com/docs/prefligh
 ##### v3 and older
 
 ```css
-@import url('@ks-digital/designsystem-themes/tailwind.base.css');
+@import url('@ks-digital/designsystem-themes/base.tailwind.css');
 @import url('@ks-digital/designsystem-themes/ledsagerbevis.css');
 
 @layer tailwind-base, ds;

--- a/packages/themes/README.md
+++ b/packages/themes/README.md
@@ -26,8 +26,7 @@ If your bundler (e.g., Vite) is configured to resolve npm packages in CSS import
 
 #### Tailwind
 
-If you are using Tailwind with (Preflight)[https://tailwindcss.com/docs/preflight] make sure to load Designsystemet first, and import the
-`base.tailwind.css` instead. `base.tailwind.css` containts the `base.css` and certain overrides needed to make Designsystemet and Tailwind work smoothly together.
+If you are using Tailwind with [Preflight](https://tailwindcss.com/docs/preflight), ensure that you load the Designsystemet styles first by importing `base.tailwind.css` instead of `base.css`. The `base.tailwind.css` file includes all of `base.css` along with some overrides to ensure smooth integration between Designsystemet and Tailwind.
 
 ##### v4
 

--- a/packages/themes/README.md
+++ b/packages/themes/README.md
@@ -26,12 +26,13 @@ If your bundler (e.g., Vite) is configured to resolve npm packages in CSS import
 
 #### Tailwind
 
-If you are using Tailwind with (Preflight)[https://tailwindcss.com/docs/preflight] make sure to load Designsystemet first.
+If you are using Tailwind with (Preflight)[https://tailwindcss.com/docs/preflight] make sure to load Designsystemet first, and import the
+`base.tailwind.css` instead. `base.tailwind.css` containts the `base.css` and certain overrides needed to make Designsystemet and Tailwind work smoothly together.
 
 ##### v4
 
 ```css
-@import url('@ks-digital/designsystem-themes/base.css');
+@import url('@ks-digital/designsystem-themes/base.tailwind.css');
 @import url('@ks-digital/designsystem-themes/ledsagerbevis.css');
 @import url('tailwindcss');
 ```
@@ -39,7 +40,7 @@ If you are using Tailwind with (Preflight)[https://tailwindcss.com/docs/prefligh
 ##### v3 and older
 
 ```css
-@import url('@ks-digital/designsystem-themes/base.css');
+@import url('@ks-digital/designsystem-themes/tailwind.base.css');
 @import url('@ks-digital/designsystem-themes/ledsagerbevis.css');
 
 @layer tailwind-base, ds;

--- a/packages/themes/package.json
+++ b/packages/themes/package.json
@@ -28,6 +28,6 @@
     "rimraf": "^6.0.1"
   },
   "scripts": {
-    "build": "rimraf dist && postcss src/base.css -o dist/base.css && cp -r src/themes dist/"
+    "build": "./scripts/build.sh"
   }
 }

--- a/packages/themes/package.json
+++ b/packages/themes/package.json
@@ -14,6 +14,7 @@
   "type": "module",
   "exports": {
     "./base.css": "./dist/base.css",
+    "./base.tailwind.css": "./dist/base.tailwind.css",
     "./ledsagerbevis.css": "./dist/themes/ledsagerbevis.css",
     "./forvaltning.css": "./dist/themes/forvaltning.css"
   },

--- a/packages/themes/scripts/build.sh
+++ b/packages/themes/scripts/build.sh
@@ -15,5 +15,5 @@ mkdir -p dist dist/themes
 postcss src/base.css -o dist/base.css
 postcss src/base.tailwind.css -o dist/base.tailwind.css
 
-# Copy theme css files
+# Copy theme css files. They don't need postcss processing
 cp -a src/themes/. dist/themes/

--- a/packages/themes/scripts/build.sh
+++ b/packages/themes/scripts/build.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+
+# Always run from the package root regardless of where the script is invoked from
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PACKAGE_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+cd "${PACKAGE_DIR}"
+
+# Clean and prepare output directories
+rimraf dist || true
+mkdir -p dist dist/themes
+
+# Build base styles
+postcss src/base.css -o dist/base.css
+postcss src/base.tailwind.css -o dist/base.tailwind.css
+
+# Copy theme css files
+cp -a src/themes/. dist/themes/

--- a/packages/themes/src/base.tailwind.css
+++ b/packages/themes/src/base.tailwind.css
@@ -1,0 +1,2 @@
+@import './base.css';
+@import './tailwind-overrides.css';

--- a/packages/themes/src/tailwind-overrides.css
+++ b/packages/themes/src/tailwind-overrides.css
@@ -1,0 +1,17 @@
+@layer tailwind-base {
+  /* Tailwind preflight resets border-styles. We redefine them to get ds-styling.
+  https://tailwindcss.com/docs/preflight#border-styles-are-reset
+  */
+  .ds-card {
+    border-width: var(--dsc-card-border-width);
+    border-style: var(--dsc-card-border-style);
+    border-color: var(--dsc-card-border-color);
+  }
+
+  .ds-details {
+    border-top-width: var(--dsc-details-border-block-width);
+    border-bottom-width: var(--dsc-details-border-block-width);
+    border-style: var(--dsc-details-border-block-style);
+    border-color: var(--dsc-details-border-color);
+  }
+}


### PR DESCRIPTION
## What is the current behavior?
Tailwind preflight overrides some Designsystemet border-styles. Context: https://tailwindcss.com/docs/preflight#border-styles-are-reset

## What is the new behavior?
Introduce `base.tailwind.css` as an option for Tailwind users, which includes needed Tailwind resets

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) describes this PR best?
