### PR TITLE
fix(themes): popover tailwind overrides

### DIFF
--- a/packages/themes/src/tailwind-overrides.css
+++ b/packages/themes/src/tailwind-overrides.css
@@ -14,4 +14,16 @@
     border-style: var(--dsc-details-border-block-style);
     border-color: var(--dsc-details-border-color);
   }
+
+  .ds-popover {
+    border-color: var(--dsc-popover-border-color);
+    border-style: var(--dsc-popover-border-style);
+    border-width: var(--dsc-popover-border-width);
+  }
+
+  .ds-popover:before {
+    border-left-color: transparent;
+    border-top-color: transparent;
+    border-width: var(--dsc-popover-border-width);
+  }
 }


### PR DESCRIPTION
## What is the current behavior?
Popover + tailwind preflight [conflicts](https://tailwindcss.com/docs/preflight#border-styles-are-reset)

## What is the new behavior?
Popover works with tailwind preflight


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) describes this PR best?
