### PR TITLE
fix(angular/suggestion): custom filtering and various issues

### DIFF
--- a/packages/angular/suggestion/src/index.ts
+++ b/packages/angular/suggestion/src/index.ts
@@ -1,4 +1,9 @@
 export { Suggestion } from './suggestion'
 export { SuggestionList } from './suggestion-list'
+export { SuggestionListEmpty } from './suggestion-list-empty'
 export { SuggestionListOption } from './suggestion-list-option'
-export type { SuggestionItem } from './suggestion.types'
+export type {
+  SuggestionFilter,
+  SuggestionFilterArgs,
+  SuggestionItem,
+} from './suggestion.types'

--- a/packages/angular/suggestion/src/suggestion-list-empty.ts
+++ b/packages/angular/suggestion/src/suggestion-list-empty.ts
@@ -1,0 +1,19 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  TemplateRef,
+  viewChild,
+} from '@angular/core'
+
+@Component({
+  selector: 'ksd-suggestion-list-empty',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: ` <ng-template #tpl><ng-content /></ng-template> `,
+})
+export class SuggestionListEmpty {
+  /**
+   * Hack to get the content from parent component so that we can
+   * keep the dom structure needed without additional host elements
+   */
+  templateRef = viewChild<TemplateRef<unknown>>('tpl')
+}

--- a/packages/angular/suggestion/src/suggestion-list.ts
+++ b/packages/angular/suggestion/src/suggestion-list.ts
@@ -1,5 +1,6 @@
 import { NgTemplateOutlet } from '@angular/common'
 import {
+  booleanAttribute,
   ChangeDetectionStrategy,
   Component,
   contentChildren,
@@ -18,6 +19,7 @@ import { SuggestionListOption } from './suggestion-list-option'
   },
   template: `
     <u-datalist
+      [attr.data-nofilter]="noFilter() || undefined"
       [attr.data-sr-singular]="singular()"
       [attr.data-sr-plural]="plural()"
     >
@@ -30,6 +32,16 @@ import { SuggestionListOption } from './suggestion-list-option'
   `,
 })
 export class SuggestionList {
+  /**
+   * Disables built-in filtering in `u-datalist`.
+   * Set this to true when filtering is handled externally.
+   *
+   * @default false
+   */
+  readonly noFilter = input(false, {
+    transform: booleanAttribute,
+  })
+
   /**
    * Screen reader announcement template for singular result count.
    *

--- a/packages/angular/suggestion/src/suggestion-list.ts
+++ b/packages/angular/suggestion/src/suggestion-list.ts
@@ -52,7 +52,7 @@ export class SuggestionList {
    */
   readonly plural = input('%d forslag')
 
-  protected readonly options = contentChildren(SuggestionListOption, {
+  readonly options = contentChildren(SuggestionListOption, {
     descendants: true,
   })
 

--- a/packages/angular/suggestion/src/suggestion-list.ts
+++ b/packages/angular/suggestion/src/suggestion-list.ts
@@ -1,6 +1,5 @@
 import { NgTemplateOutlet } from '@angular/common'
 import {
-  booleanAttribute,
   ChangeDetectionStrategy,
   Component,
   contentChildren,
@@ -21,7 +20,6 @@ import { SuggestionListOption } from './suggestion-list-option'
     <u-datalist
       [attr.data-sr-singular]="singular()"
       [attr.data-sr-plural]="plural()"
-      [attr.data-autoplacement]="autoPlacement()"
     >
       @for (option of options(); track option) {
         <u-option [value]="option.value()">
@@ -45,15 +43,6 @@ export class SuggestionList {
    * @default '%d forslag'
    */
   readonly plural = input('%d forslag')
-
-  /**
-   * Whether to enable auto placement.
-   *
-   * @default true
-   */
-  readonly autoPlacement = input(true, {
-    transform: booleanAttribute,
-  })
 
   readonly options = contentChildren(SuggestionListOption, {
     descendants: true,

--- a/packages/angular/suggestion/src/suggestion-list.ts
+++ b/packages/angular/suggestion/src/suggestion-list.ts
@@ -1,5 +1,6 @@
 import { NgTemplateOutlet } from '@angular/common'
 import {
+  booleanAttribute,
   ChangeDetectionStrategy,
   Component,
   contentChildren,
@@ -20,6 +21,7 @@ import { SuggestionListOption } from './suggestion-list-option'
     <u-datalist
       [attr.data-sr-singular]="singular()"
       [attr.data-sr-plural]="plural()"
+      [attr.data-autoplacement]="autoPlacement()"
     >
       @for (option of options(); track option) {
         <u-option [value]="option.value()">
@@ -43,6 +45,15 @@ export class SuggestionList {
    * @default '%d forslag'
    */
   readonly plural = input('%d forslag')
+
+  /**
+   * Whether to enable auto placement.
+   *
+   * @default true
+   */
+  readonly autoPlacement = input(true, {
+    transform: booleanAttribute,
+  })
 
   readonly options = contentChildren(SuggestionListOption, {
     descendants: true,

--- a/packages/angular/suggestion/src/suggestion-list.ts
+++ b/packages/angular/suggestion/src/suggestion-list.ts
@@ -4,6 +4,7 @@ import {
   Component,
   contentChildren,
   CUSTOM_ELEMENTS_SCHEMA,
+  input,
 } from '@angular/core'
 import { SuggestionListOption } from './suggestion-list-option'
 
@@ -16,7 +17,10 @@ import { SuggestionListOption } from './suggestion-list-option'
     style: 'display: contents;',
   },
   template: `
-    <u-datalist>
+    <u-datalist
+      [attr.data-sr-singular]="singular()"
+      [attr.data-sr-plural]="plural()"
+    >
       @for (option of options(); track option) {
         <u-option [value]="option.value()">
           <ng-container *ngTemplateOutlet="option.templateRef()" />
@@ -26,6 +30,20 @@ import { SuggestionListOption } from './suggestion-list-option'
   `,
 })
 export class SuggestionList {
+  /**
+   * Screen reader announcement template for singular result count.
+   *
+   * @default '%d forslag'
+   */
+  readonly singular = input('%d forslag')
+
+  /**
+   * Screen reader announcement template for plural result count.
+   *
+   * @default '%d forslag'
+   */
+  readonly plural = input('%d forslag')
+
   readonly options = contentChildren(SuggestionListOption, {
     descendants: true,
   })

--- a/packages/angular/suggestion/src/suggestion-list.ts
+++ b/packages/angular/suggestion/src/suggestion-list.ts
@@ -1,12 +1,13 @@
 import { NgTemplateOutlet } from '@angular/common'
 import {
-  booleanAttribute,
   ChangeDetectionStrategy,
   Component,
+  contentChild,
   contentChildren,
   CUSTOM_ELEMENTS_SCHEMA,
   input,
 } from '@angular/core'
+import { SuggestionListEmpty } from './suggestion-list-empty'
 import { SuggestionListOption } from './suggestion-list-option'
 
 @Component({
@@ -19,7 +20,7 @@ import { SuggestionListOption } from './suggestion-list-option'
   },
   template: `
     <u-datalist
-      [attr.data-nofilter]="noFilter() || undefined"
+      data-nofilter
       [attr.data-sr-singular]="singular()"
       [attr.data-sr-plural]="plural()"
     >
@@ -28,20 +29,15 @@ import { SuggestionListOption } from './suggestion-list-option'
           <ng-container *ngTemplateOutlet="option.templateRef()" />
         </u-option>
       }
+      @if (empty()?.templateRef()) {
+        <u-option data-empty value="" hidden>
+          <ng-container *ngTemplateOutlet="empty()?.templateRef()" />
+        </u-option>
+      }
     </u-datalist>
   `,
 })
 export class SuggestionList {
-  /**
-   * Disables built-in filtering in `u-datalist`.
-   * Set this to true when filtering is handled externally.
-   *
-   * @default false
-   */
-  readonly noFilter = input(false, {
-    transform: booleanAttribute,
-  })
-
   /**
    * Screen reader announcement template for singular result count.
    *
@@ -56,7 +52,9 @@ export class SuggestionList {
    */
   readonly plural = input('%d forslag')
 
-  readonly options = contentChildren(SuggestionListOption, {
+  protected readonly options = contentChildren(SuggestionListOption, {
     descendants: true,
   })
+
+  protected readonly empty = contentChild(SuggestionListEmpty)
 }

--- a/packages/angular/suggestion/src/suggestion.mdx
+++ b/packages/angular/suggestion/src/suggestion.mdx
@@ -70,4 +70,60 @@ export class App {
 
 Om du ønsker å implementere eget filter, kan du gjøre det ved å lytte på `input`-eventen på input-feltet og filtrere listen av forslag selv. Sett `[filter]="false"` på `ksd-suggestion` for å deaktivere det innebygde filteret.
 
+`filter` støtter også en callback-funksjon (`SuggestionFilter`), slik at du kan sende inn egen filtreringslogikk direkte via `[filter]`.
+
+```ts
+import { Component, signal } from '@angular/core'
+import { Field, Input, Label } from '@ks-digital/designsystem-angular/forms'
+import {
+  Suggestion,
+  SuggestionList,
+  SuggestionListOption,
+  type SuggestionFilter,
+} from '@ks-digital/designsystem-angular/suggestion'
+
+@Component({
+  imports: [
+    Field,
+    Label,
+    Input,
+    Suggestion,
+    SuggestionList,
+    SuggestionListOption,
+  ],
+  template: `
+    <ksd-field>
+      <ksd-label>Velg kommune</ksd-label>
+      <ksd-suggestion [filter]="startsWithUppercaseFilter">
+        <input ksd-input />
+        <del aria-label="Tøm" hidden=""></del>
+        <ksd-suggestion-list>
+          @for (municipality of municipalities(); track municipality) {
+            <ksd-suggestion-list-option [value]="municipality">{{
+              municipality
+            }}</ksd-suggestion-list-option>
+          }
+        </ksd-suggestion-list>
+      </ksd-suggestion>
+    </ksd-field>
+  `,
+})
+export class App {
+  municipalities = signal(['Bergen', 'Oslo', 'Stavanger', 'Molde'])
+
+  startsWithUppercaseFilter: SuggestionFilter = ({ label, input }) => {
+    const value = input.value.trim()
+    if (!value) return true
+
+    const firstLetter = value.charAt(0)
+    const isLetter = firstLetter.toLowerCase() !== firstLetter.toUpperCase()
+    const isUppercase = firstLetter === firstLetter.toUpperCase()
+
+    if (!isLetter || !isUppercase) return false
+
+    return label.startsWith(firstLetter)
+  }
+}
+```
+
 <Canvas of={SuggestionStories.CustomFiltering} />

--- a/packages/angular/suggestion/src/suggestion.mdx
+++ b/packages/angular/suggestion/src/suggestion.mdx
@@ -68,10 +68,6 @@ export class App {
 
 ### Eget filter
 
-Om du ønsker å implementere eget filter, kan du gjøre det ved å lytte på `input`-eventen på input-feltet og filtrere listen av forslag selv. Sett `[filter]="false"` på `ksd-suggestion` for å deaktivere det innebygde filteret.
-
-`filter` støtter også en callback-funksjon (`SuggestionFilter`), slik at du kan sende inn egen filtreringslogikk direkte via `[filter]`.
-
 ```ts
 import { Component, signal } from '@angular/core'
 import { Field, Input, Label } from '@ks-digital/designsystem-angular/forms'

--- a/packages/angular/suggestion/src/suggestion.mdx
+++ b/packages/angular/suggestion/src/suggestion.mdx
@@ -65,6 +65,6 @@ export class App {
 
 ### Eget filter
 
-Om du ønsker å implementere eget filter, kan du gjøre det ved å lytte på `input`-eventen på input-feltet og filtrere listen av forslag selv.
+Om du ønsker å implementere eget filter, kan du gjøre det ved å lytte på `input`-eventen på input-feltet og filtrere listen av forslag selv. Sett `noFilter`-attributtet på `ksd-suggestion-list` for å deaktivere det innebygde filteret.
 
 <Canvas of={SuggestionStories.CustomFiltering} />

--- a/packages/angular/suggestion/src/suggestion.mdx
+++ b/packages/angular/suggestion/src/suggestion.mdx
@@ -25,6 +25,7 @@ import {
   Suggestion,
   type SuggestionItem,
   SuggestionList,
+  SuggestionListEmpty,
   SuggestionListOption,
 } from '@ks-digital/designsystem-angular/suggestion'
 
@@ -35,6 +36,7 @@ import {
     Input,
     Suggestion,
     SuggestionList,
+    SuggestionListEmpty,
     SuggestionListOption,
   ],
   template: `
@@ -47,24 +49,25 @@ import {
         <input ksd-input />
         <del aria-label="Tøm" hidden=""></del>
         <ksd-suggestion-list>
-          <ksd-suggestion-list-option value="Sogndal"
-            >Sogndal</ksd-suggestion-list-option
-          >
-          <ksd-suggestion-list-option value="Oslo"
-            >Oslo</ksd-suggestion-list-option
-          >
+          @for (place of places(); track place) {
+            <ksd-suggestion-list-option [value]="place">{{
+              place
+            }}</ksd-suggestion-list-option>
+          }
+          <ksd-suggestion-list-empty>Ingen treff</ksd-suggestion-list-empty>
         </ksd-suggestion-list>
       </ksd-suggestion>
     </ksd-field>
   `,
 })
 export class App {
+  places = signal(['Bergen', 'Oslo'])
   selected = signal<SuggestionItem | undefined>(undefined)
 }
 ```
 
 ### Eget filter
 
-Om du ønsker å implementere eget filter, kan du gjøre det ved å lytte på `input`-eventen på input-feltet og filtrere listen av forslag selv. Sett `noFilter`-attributtet på `ksd-suggestion-list` for å deaktivere det innebygde filteret.
+Om du ønsker å implementere eget filter, kan du gjøre det ved å lytte på `input`-eventen på input-feltet og filtrere listen av forslag selv. Sett `[filter]="false"` på `ksd-suggestion` for å deaktivere det innebygde filteret.
 
 <Canvas of={SuggestionStories.CustomFiltering} />

--- a/packages/angular/suggestion/src/suggestion.spec.ts
+++ b/packages/angular/suggestion/src/suggestion.spec.ts
@@ -1,8 +1,13 @@
+import { signal } from '@angular/core'
 import { Input } from '@ks-digital/designsystem-angular/forms'
 import { render, waitFor } from '@testing-library/angular'
 import { vi } from 'vitest'
 import { axe } from 'vitest-axe'
-import { SuggestionList, SuggestionListOption } from './index'
+import {
+  SuggestionList,
+  SuggestionListEmpty,
+  SuggestionListOption,
+} from './index'
 import { Suggestion } from './suggestion'
 import type { SuggestionFilter, SuggestionItem } from './suggestion.types'
 
@@ -265,6 +270,50 @@ describe('Suggestion', () => {
 
       await waitFor(() => {
         expect(bergenOption).toHaveAttribute('aria-hidden', 'false')
+      })
+    })
+
+    it('should show empty option when projected options become empty', async () => {
+      const showOptions = signal(true)
+
+      const { container } = await render(
+        `
+        <ksd-suggestion [filter]="false">
+          <input ksd-input />
+          <ksd-suggestion-list>
+            @if (showOptions()) {
+              <ksd-suggestion-list-option value="4601">Bergen</ksd-suggestion-list-option>
+            }
+            <ksd-suggestion-list-empty>Ingen treff</ksd-suggestion-list-empty>
+          </ksd-suggestion-list>
+        </ksd-suggestion>
+      `,
+        {
+          imports: [
+            Suggestion,
+            SuggestionList,
+            SuggestionListOption,
+            SuggestionListEmpty,
+            Input,
+          ],
+          componentProperties: {
+            showOptions,
+          },
+        },
+      )
+
+      const bergenOption = container.querySelector('u-option[value="4601"]')
+      const emptyOption = container.querySelector('u-option[data-empty]')
+
+      expect(bergenOption).toBeInTheDocument()
+      expect(emptyOption).toBeInTheDocument()
+
+      if (!bergenOption || !emptyOption) return
+
+      showOptions.set(false)
+
+      await waitFor(() => {
+        expect(emptyOption).not.toHaveAttribute('hidden')
       })
     })
 

--- a/packages/angular/suggestion/src/suggestion.spec.ts
+++ b/packages/angular/suggestion/src/suggestion.spec.ts
@@ -267,5 +267,34 @@ describe('Suggestion', () => {
         expect(bergenOption).toHaveAttribute('aria-hidden', 'false')
       })
     })
+
+    it('should apply custom filter callback to the rendered options', async () => {
+      const customFilter: SuggestionFilter = ({ label }) => label === 'Bergen'
+      const { container } = await renderSuggestionWithList({
+        filter: customFilter,
+      })
+
+      const bergenOption = container.querySelector<HTMLOptionElement>(
+        'u-option[value="4601"]',
+      )
+      const osloOption = container.querySelector<HTMLOptionElement>(
+        'u-option[value="0301"]',
+      )
+      const stavangerOption = container.querySelector<HTMLOptionElement>(
+        'u-option[value="1103"]',
+      )
+
+      expect(bergenOption).toBeInTheDocument()
+      expect(osloOption).toBeInTheDocument()
+      expect(stavangerOption).toBeInTheDocument()
+
+      if (!bergenOption || !osloOption || !stavangerOption) return
+
+      await waitFor(() => {
+        expect(bergenOption.disabled).toBe(false)
+        expect(osloOption.disabled).toBe(true)
+        expect(stavangerOption.disabled).toBe(true)
+      })
+    })
   })
 })

--- a/packages/angular/suggestion/src/suggestion.spec.ts
+++ b/packages/angular/suggestion/src/suggestion.spec.ts
@@ -1,11 +1,14 @@
 import { Input } from '@ks-digital/designsystem-angular/forms'
-import { render } from '@testing-library/angular'
+import { render, waitFor } from '@testing-library/angular'
 import { vi } from 'vitest'
+import { axe } from 'vitest-axe'
+import { SuggestionList, SuggestionListOption } from './index'
 import { Suggestion } from './suggestion'
-import type { SuggestionItem } from './suggestion.types'
+import type { SuggestionFilter, SuggestionItem } from './suggestion.types'
 
 type RenderSuggestionProps = {
   creatable?: boolean
+  filter?: boolean | SuggestionFilter
   multiple?: boolean
   onSelectedChange?: (value: SuggestionItem | SuggestionItem[] | null) => void
   selected?: SuggestionItem | SuggestionItem[] | null
@@ -13,6 +16,7 @@ type RenderSuggestionProps = {
 
 const renderSuggestion = async ({
   creatable = false,
+  filter = true,
   multiple = false,
   onSelectedChange = vi.fn(),
   selected = null,
@@ -21,6 +25,7 @@ const renderSuggestion = async ({
     `
 			<ksd-suggestion
 				[creatable]="creatable"
+        [filter]="filter"
 				[multiple]="multiple"
 				[selected]="selected"
 				(selectedChange)="onSelectedChange($event)"
@@ -32,6 +37,43 @@ const renderSuggestion = async ({
       imports: [Suggestion, Input],
       componentProperties: {
         creatable,
+        filter,
+        multiple,
+        onSelectedChange,
+        selected,
+      },
+    },
+  )
+
+const renderSuggestionWithList = async ({
+  creatable = false,
+  filter = true,
+  multiple = false,
+  onSelectedChange = vi.fn(),
+  selected = null,
+}: RenderSuggestionProps = {}) =>
+  render(
+    `
+			<ksd-suggestion
+				[creatable]="creatable"
+				[filter]="filter"
+				[multiple]="multiple"
+				[selected]="selected"
+				(selectedChange)="onSelectedChange($event)"
+			>
+				<input ksd-input />
+				<ksd-suggestion-list>
+					<ksd-suggestion-list-option value="4601">Bergen</ksd-suggestion-list-option>
+					<ksd-suggestion-list-option value="0301">Oslo</ksd-suggestion-list-option>
+					<ksd-suggestion-list-option value="1103">Stavanger</ksd-suggestion-list-option>
+				</ksd-suggestion-list>
+			</ksd-suggestion>
+		`,
+    {
+      imports: [Suggestion, SuggestionList, SuggestionListOption, Input],
+      componentProperties: {
+        creatable,
+        filter,
         multiple,
         onSelectedChange,
         selected,
@@ -40,6 +82,27 @@ const renderSuggestion = async ({
   )
 
 describe('Suggestion', () => {
+  it('should have no obvious accessibility violations', async () => {
+    const { container } = await render(
+      `
+        <ksd-suggestion>
+          <input ksd-input />
+          <ksd-suggestion-list>
+            <ksd-suggestion-list-option value="4601">Bergen</ksd-suggestion-list-option>
+            <ksd-suggestion-list-option value="0301">Oslo</ksd-suggestion-list-option>
+            <ksd-suggestion-list-option value="1103">Stavanger</ksd-suggestion-list-option>
+          </ksd-suggestion-list>
+        </ksd-suggestion>
+      `,
+      {
+        imports: [Suggestion, SuggestionList, SuggestionListOption, Input],
+      },
+    )
+
+    const results = await axe(container)
+    expect(results).toHaveNoViolations()
+  })
+
   it('should render selected item as data element', async () => {
     const selected: SuggestionItem = {
       label: 'Option 1',
@@ -125,22 +188,84 @@ describe('Suggestion', () => {
     ])
   })
 
-  it('should clear input value on Escape key', async () => {
+  it('should prevent default on Escape key', async () => {
     const { container } = await renderSuggestion()
-    const input = container.querySelector('input')
+    const dsSuggestion = container.querySelector('ds-suggestion')
 
-    expect(input).toBeInTheDocument()
-    if (!input) return
+    expect(dsSuggestion).toBeInTheDocument()
+    if (!dsSuggestion) return
 
-    input.value = 'Stavanger'
-    input.dispatchEvent(
-      new KeyboardEvent('keydown', {
-        key: 'Escape',
-        bubbles: true,
-        cancelable: true,
-      }),
-    )
+    const event = new KeyboardEvent('keydown', {
+      key: 'Escape',
+      bubbles: true,
+      cancelable: true,
+    })
 
-    expect(input.value).toBe('')
+    dsSuggestion.dispatchEvent(event)
+
+    expect(event.defaultPrevented).toBe(true)
+  })
+
+  describe('Filtering', () => {
+    it('should set data-nofilter on u-datalist', async () => {
+      const { container } = await renderSuggestionWithList({ filter: false })
+
+      expect(container.querySelector('u-datalist')).toHaveAttribute(
+        'data-nofilter',
+      )
+    })
+
+    it('should not use built-in filtering when filter is disabled', async () => {
+      const { container } = await renderSuggestionWithList({ filter: false })
+
+      const input = container.querySelector('input')
+      const bergenOption = container.querySelector('u-option[value="4601"]')
+      const osloOption = container.querySelector('u-option[value="0301"]')
+
+      expect(input).toBeInTheDocument()
+      expect(bergenOption).toBeInTheDocument()
+      expect(osloOption).toBeInTheDocument()
+
+      if (!input || !bergenOption || !osloOption) return
+
+      input.value = 'Bx'
+      input.dispatchEvent(new Event('input', { bubbles: true }))
+
+      await waitFor(() => {
+        expect(bergenOption).toHaveAttribute('aria-hidden', 'false')
+        expect(osloOption).toHaveAttribute('aria-hidden', 'false')
+      })
+    })
+
+    it('should keep options visible when filtering is disabled', async () => {
+      const { container } = await render(
+        `
+        <ksd-suggestion [filter]="false">
+          <input ksd-input />
+          <ksd-suggestion-list>
+            <ksd-suggestion-list-option value="4601">Bergen</ksd-suggestion-list-option>
+          </ksd-suggestion-list>
+        </ksd-suggestion>
+      `,
+        {
+          imports: [Suggestion, SuggestionList, SuggestionListOption, Input],
+        },
+      )
+
+      const input = container.querySelector('input')
+      const bergenOption = container.querySelector('u-option[value="4601"]')
+
+      expect(input).toBeInTheDocument()
+      expect(bergenOption).toBeInTheDocument()
+
+      if (!input || !bergenOption) return
+
+      input.value = 'Bx'
+      input.dispatchEvent(new Event('input', { bubbles: true }))
+
+      await waitFor(() => {
+        expect(bergenOption).toHaveAttribute('aria-hidden', 'false')
+      })
+    })
   })
 })

--- a/packages/angular/suggestion/src/suggestion.spec.ts
+++ b/packages/angular/suggestion/src/suggestion.spec.ts
@@ -124,4 +124,23 @@ describe('Suggestion', () => {
       },
     ])
   })
+
+  it('should clear input value on Escape key', async () => {
+    const { container } = await renderSuggestion()
+    const input = container.querySelector('input')
+
+    expect(input).toBeInTheDocument()
+    if (!input) return
+
+    input.value = 'Stavanger'
+    input.dispatchEvent(
+      new KeyboardEvent('keydown', {
+        key: 'Escape',
+        bubbles: true,
+        cancelable: true,
+      }),
+    )
+
+    expect(input.value).toBe('')
+  })
 })

--- a/packages/angular/suggestion/src/suggestion.stories.ts
+++ b/packages/angular/suggestion/src/suggestion.stories.ts
@@ -113,7 +113,7 @@ export const Preview: Story = {
           <del aria-label="Tøm" hidden=""></del>
           <ksd-suggestion-list>
             @for (place of places; track place) {
-              <ksd-suggestion-list-option [value]="place">{{ place }}</ksd-suggestion-list-option>  
+              <ksd-suggestion-list-option [value]="place">{{ place }}</ksd-suggestion-list-option>
             }
             <ksd-suggestion-list-empty>Ingen treff</ksd-suggestion-list-empty>
           </ksd-suggestion-list>

--- a/packages/angular/suggestion/src/suggestion.stories.ts
+++ b/packages/angular/suggestion/src/suggestion.stories.ts
@@ -10,7 +10,12 @@ import {
   type StoryObj,
 } from '@storybook/angular'
 import { CommonArgs, commonArgTypes } from '../../.storybook/default-args'
-import { Suggestion, SuggestionList, SuggestionListOption } from './index'
+import {
+  Suggestion,
+  SuggestionList,
+  SuggestionListEmpty,
+  SuggestionListOption,
+} from './index'
 import type { SuggestionItem } from './suggestion.types'
 
 type SuggestionArgs = CommonArgs & {
@@ -49,6 +54,7 @@ const meta: Meta<SuggestionArgs> = {
       imports: [
         Suggestion,
         SuggestionList,
+        SuggestionListEmpty,
         SuggestionListOption,
         Button,
         Field,
@@ -107,8 +113,9 @@ export const Preview: Story = {
           <del aria-label="Tøm" hidden=""></del>
           <ksd-suggestion-list>
             @for (place of places; track place) {
-              <ksd-suggestion-list-option [value]="place">{{ place }}</ksd-suggestion-list-option>
+              <ksd-suggestion-list-option [value]="place">{{ place }}</ksd-suggestion-list-option>  
             }
+            <ksd-suggestion-list-empty>Ingen treff</ksd-suggestion-list-empty>
           </ksd-suggestion-list>
         </ksd-suggestion>
       </ksd-field>
@@ -152,6 +159,7 @@ export const ControlledSingle: Story = {
               @for (place of places; track place) {
                 <ksd-suggestion-list-option [value]="place">{{ place }}</ksd-suggestion-list-option>
               }
+              <ksd-suggestion-list-empty>Ingen treff</ksd-suggestion-list-empty>
             </ksd-suggestion-list>
           </ksd-suggestion>
         </ksd-field>
@@ -202,6 +210,7 @@ export const ControlledMultiple: Story = {
               @for (place of places; track place) {
                 <ksd-suggestion-list-option [value]="place">{{ place }}</ksd-suggestion-list-option>
               }
+              <ksd-suggestion-list-empty>Ingen treff</ksd-suggestion-list-empty>
             </ksd-suggestion-list>
           </ksd-suggestion>
         </ksd-field>
@@ -254,6 +263,7 @@ export const ControlledIndependentLabelValue: Story = {
               @for (municipality of municipalities; track municipality.value) {
                 <ksd-suggestion-list-option [value]="municipality.value">{{ municipality.label }}</ksd-suggestion-list-option>
               }
+              <ksd-suggestion-list-empty>Ingen treff</ksd-suggestion-list-empty>
             </ksd-suggestion-list>
           </ksd-suggestion>
         </ksd-field>
@@ -298,6 +308,7 @@ export const DefaultValue: Story = {
             @for (place of places; track place) {
               <ksd-suggestion-list-option [value]="place">{{ place }}</ksd-suggestion-list-option>
             }
+            <ksd-suggestion-list-empty>Ingen treff</ksd-suggestion-list-empty>
           </ksd-suggestion-list>
         </ksd-suggestion>
       </ksd-field>
@@ -329,6 +340,7 @@ export const Multiple: Story = {
             @for (place of places; track place) {
               <ksd-suggestion-list-option [value]="place">{{ place }}</ksd-suggestion-list-option>
             }
+            <ksd-suggestion-list-empty>Ingen treff</ksd-suggestion-list-empty>
           </ksd-suggestion-list>
         </ksd-suggestion>
       </ksd-field>
@@ -360,6 +372,7 @@ export const Creatable: Story = {
             @for (place of places; track place) {
               <ksd-suggestion-list-option [value]="place">{{ place }}</ksd-suggestion-list-option>
             }
+            <ksd-suggestion-list-empty>Ingen treff</ksd-suggestion-list-empty>
           </ksd-suggestion-list>
         </ksd-suggestion>
       </ksd-field>
@@ -409,6 +422,7 @@ export const CustomFiltering: Story = {
             ${suggestionArgsToTemplate(args)}
             [multiple]="multiple"
             [creatable]="creatable"
+            [filter]="false"
             [selected]="selected()"
             (selectedChange)="onSelectedChange($event)"
           >
@@ -417,10 +431,11 @@ export const CustomFiltering: Story = {
               (input)="onInput($event)"
             />
             <del aria-label="Tøm" hidden=""></del>
-            <ksd-suggestion-list noFilter>
+            <ksd-suggestion-list>
               @for (municipality of filteredMunicipalities(); track municipality.value) {
                 <ksd-suggestion-list-option [value]="municipality.value">{{ municipality.label }}</ksd-suggestion-list-option>
               }
+              <ksd-suggestion-list-empty>Ingen treff</ksd-suggestion-list-empty>
             </ksd-suggestion-list>
           </ksd-suggestion>
         </ksd-field>

--- a/packages/angular/suggestion/src/suggestion.stories.ts
+++ b/packages/angular/suggestion/src/suggestion.stories.ts
@@ -417,7 +417,7 @@ export const CustomFiltering: Story = {
               (input)="onInput($event)"
             />
             <del aria-label="Tøm" hidden=""></del>
-            <ksd-suggestion-list>
+            <ksd-suggestion-list noFilter>
               @for (municipality of filteredMunicipalities(); track municipality.value) {
                 <ksd-suggestion-list-option [value]="municipality.value">{{ municipality.label }}</ksd-suggestion-list-option>
               }

--- a/packages/angular/suggestion/src/suggestion.ts
+++ b/packages/angular/suggestion/src/suggestion.ts
@@ -4,7 +4,9 @@ import {
   ChangeDetectionStrategy,
   Component,
   computed,
+  contentChild,
   CUSTOM_ELEMENTS_SCHEMA,
+  effect,
   ElementRef,
   input,
   model,
@@ -15,6 +17,7 @@ import {
   HostColor,
   HostSize,
 } from '@ks-digital/designsystem-angular/__internals'
+import { SuggestionList } from './suggestion-list'
 import type {
   SuggestionFilter,
   SuggestionFilterArgs,
@@ -89,9 +92,15 @@ export class Suggestion {
   protected selectedArray = computed(() => sanitizeItems(this.selected()))
   private readonly suggestionElement =
     viewChild<ElementRef<HTMLElement>>('suggestionElement')
+  private readonly suggestionList = contentChild(SuggestionList)
 
   constructor() {
     afterNextRender(() => this.syncOptions(null))
+
+    effect(() => {
+      this.suggestionList()?.options()
+      queueMicrotask(() => this.syncOptions(null))
+    })
   }
 
   protected onSelect(event: Event) {

--- a/packages/angular/suggestion/src/suggestion.ts
+++ b/packages/angular/suggestion/src/suggestion.ts
@@ -1,19 +1,29 @@
 import {
+  afterNextRender,
   booleanAttribute,
   ChangeDetectionStrategy,
   Component,
   computed,
   CUSTOM_ELEMENTS_SCHEMA,
+  ElementRef,
   input,
   model,
+  viewChild,
 } from '@angular/core'
 import '@digdir/designsystemet-web'
 import {
   HostColor,
   HostSize,
 } from '@ks-digital/designsystem-angular/__internals'
-import type { SuggestionItem } from './suggestion.types'
+import type {
+  SuggestionFilter,
+  SuggestionFilterArgs,
+  SuggestionItem,
+} from './suggestion.types'
 import { nextSelected, sanitizeItems } from './suggestion.utils'
+
+const defaultFilter = ({ label, input }: SuggestionFilterArgs) =>
+  label.toLowerCase().includes(input.value.trim().toLowerCase())
 
 @Component({
   selector: 'ksd-suggestion',
@@ -32,10 +42,12 @@ import { nextSelected, sanitizeItems } from './suggestion.utils'
   host: {},
   template: `
     <ds-suggestion
+      #suggestionElement
       class="ds-suggestion"
       [attr.data-multiple]="multiple() || undefined"
       [attr.data-creatable]="creatable() || undefined"
       (comboboxbeforeselect)="onSelect($event)"
+      (input)="onInput($event)"
       (keydown)="onKeyDown($event)"
     >
       @for (option of selectedArray(); track option.value) {
@@ -61,6 +73,13 @@ export class Suggestion {
   creatable = input(false, { transform: booleanAttribute })
 
   /**
+   * Filter options; boolean or a custom callback.
+   *
+   * @default true
+   */
+  filter = input<boolean | SuggestionFilter>(true)
+
+  /**
    * Model for the selected item(s).
    *
    * @default undefined
@@ -68,6 +87,12 @@ export class Suggestion {
   selected = model<SuggestionItem | SuggestionItem[] | undefined>(undefined)
 
   protected selectedArray = computed(() => sanitizeItems(this.selected()))
+  private readonly suggestionElement =
+    viewChild<ElementRef<HTMLElement>>('suggestionElement')
+
+  constructor() {
+    afterNextRender(() => this.syncOptions(null))
+  }
 
   protected onSelect(event: Event) {
     const customEvent = event as CustomEvent<HTMLDataElement | undefined>
@@ -84,5 +109,62 @@ export class Suggestion {
     if (keyboardEvent.key !== 'Escape') return
 
     event.preventDefault()
+  }
+
+  protected onInput(event: Event) {
+    const inputElement = event.target as HTMLInputElement | null
+    setTimeout(() => this.syncOptions(inputElement))
+  }
+
+  private syncOptions(inputElement: HTMLInputElement | null) {
+    const suggestionElement = this.suggestionElement()?.nativeElement
+    if (!suggestionElement) return
+
+    const input =
+      inputElement ?? suggestionElement.querySelector<HTMLInputElement>('input')
+
+    const options = Array.from(
+      suggestionElement.querySelectorAll<HTMLOptionElement>(
+        'u-option:not([data-empty])',
+      ),
+    )
+
+    const filter = this.filter()
+    const filterFn = filter === true ? defaultFilter : filter
+
+    if (filterFn && input) {
+      let index = 0
+      for (const option of options) {
+        option.disabled = !filterFn({
+          index,
+          input,
+          label: option.label,
+          optionElement: option,
+          text: option.text,
+          value: option.value,
+        })
+        index++
+      }
+    } else {
+      for (const option of options) {
+        option.disabled = false
+      }
+    }
+
+    const visibleOptions = options.filter(
+      (option) => !option.disabled && !option.hidden,
+    )
+    const emptyOption = suggestionElement.querySelector<HTMLOptionElement>(
+      'u-option[data-empty]',
+    )
+
+    if (!emptyOption) return
+
+    if (visibleOptions.length === 0) {
+      emptyOption.removeAttribute('hidden')
+      return
+    }
+
+    emptyOption.setAttribute('hidden', '')
   }
 }

--- a/packages/angular/suggestion/src/suggestion.ts
+++ b/packages/angular/suggestion/src/suggestion.ts
@@ -36,6 +36,7 @@ import { nextSelected, sanitizeItems } from './suggestion.utils'
       [attr.data-multiple]="multiple() || undefined"
       [attr.data-creatable]="creatable() || undefined"
       (comboboxbeforeselect)="onSelect($event)"
+      (keydown)="onKeyDown($event)"
     >
       @for (option of selectedArray(); track option.value) {
         <data [attr.value]="option.value">{{ option.label }}</data>
@@ -76,5 +77,12 @@ export class Suggestion {
     if (!data) return
 
     this.selected.set(nextSelected(data, this.selected(), this.multiple()))
+  }
+
+  protected onKeyDown(event: Event) {
+    const keyboardEvent = event as KeyboardEvent
+    if (keyboardEvent.key !== 'Escape') return
+
+    event.preventDefault()
   }
 }

--- a/packages/angular/suggestion/src/suggestion.types.ts
+++ b/packages/angular/suggestion/src/suggestion.types.ts
@@ -1,5 +1,16 @@
 export type SuggestionItem = { label: string; value: string }
 
+export type SuggestionFilterArgs = {
+  index: number
+  label: string
+  text: string
+  value: string
+  optionElement: HTMLOptionElement
+  input: HTMLInputElement
+}
+
+export type SuggestionFilter = (args: SuggestionFilterArgs) => boolean
+
 export type SuggestionModelValue =
   | SuggestionItem
   | SuggestionItem[]


### PR DESCRIPTION

## What is the current behavior?
- Some aria-attributes were not translatable
- Custom filtering not working as expected
- Escape doesnt clear the input
- No component for empty option like React has


## What is the new behavior?
- Consumers can override translations for some aria-attributes, defaults to Norwegian
- Custom should work according to docs
- Escape clears the input
- New component for  empty option


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Checklist

- [x] 📦 I have updated the public API (for example, if a new component was added)
- [x] 🧪 Tests - I have added or updated tests that cover my changes (if applicable)
- [x] 📝 Documentation - I have updated relevant documentation, README, or comments (if applicable)
- [ ] 🔗 I have linked all related issues or discussions

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) describes this PR best?
