### PR TITLE
fix(angular/tabs): wrong font-size for projected tab-icons

### DIFF
--- a/packages/angular/tabs/src/tabs.stories.ts
+++ b/packages/angular/tabs/src/tabs.stories.ts
@@ -1,4 +1,9 @@
 import { Button } from '@ks-digital/designsystem-angular/button'
+import { NgIcon, provideIcons } from '@ng-icons/core'
+import {
+  phosphorArrowUpRight,
+  phosphorPencilLine,
+} from '@ng-icons/phosphor-icons/regular'
 import { argsToTemplate, Meta, moduleMetadata } from '@storybook/angular'
 import { CommonArgs, commonArgTypes } from '../../.storybook/default-args'
 import { Tabs, TabsList, TabsPanel, TabsTab } from './'
@@ -13,7 +18,8 @@ const meta: Meta<TabsArgs> = {
   },
   decorators: [
     moduleMetadata({
-      imports: [Tabs, TabsList, TabsTab, TabsPanel, Button],
+      imports: [Tabs, TabsList, TabsTab, TabsPanel, Button, NgIcon],
+      providers: [provideIcons({ phosphorPencilLine, phosphorArrowUpRight })],
     }),
   ],
 }
@@ -33,6 +39,30 @@ export const Preview: Story = {
         </ksd-tabs-list>
         <ksd-tabs-panel>content 1</ksd-tabs-panel>
         <ksd-tabs-panel>content 2</ksd-tabs-panel>
+      </ksd-tabs>
+    `,
+  }),
+}
+
+export const WithIcons: Story = {
+  render: (args) => ({
+    props: {
+      ...args,
+    },
+    template: `
+      <ksd-tabs ${argsToTemplate(args)}>
+        <ksd-tabs-list>
+          <ksd-tabs-tab>
+            <ng-icon name="phosphorPencilLine" />
+            <span>Rediger</span>
+          </ksd-tabs-tab>
+          <ksd-tabs-tab>
+            <ng-icon name="phosphorArrowUpRight" />
+            <span>Lenker</span>
+          </ksd-tabs-tab>
+        </ksd-tabs-list>
+        <ksd-tabs-panel>Innhold for Rediger</ksd-tabs-panel>
+        <ksd-tabs-panel>Innhold for Lenker</ksd-tabs-panel>
       </ksd-tabs>
     `,
   }),

--- a/packages/angular/tabs/src/tabs.stories.ts
+++ b/packages/angular/tabs/src/tabs.stories.ts
@@ -1,9 +1,6 @@
 import { Button } from '@ks-digital/designsystem-angular/button'
 import { NgIcon, provideIcons } from '@ng-icons/core'
-import {
-  phosphorArrowUpRight,
-  phosphorPencilLine,
-} from '@ng-icons/phosphor-icons/regular'
+import { phosphorGear, phosphorUsers } from '@ng-icons/phosphor-icons/regular'
 import { argsToTemplate, Meta, moduleMetadata } from '@storybook/angular'
 import { CommonArgs, commonArgTypes } from '../../.storybook/default-args'
 import { Tabs, TabsList, TabsPanel, TabsTab } from './'
@@ -19,7 +16,7 @@ const meta: Meta<TabsArgs> = {
   decorators: [
     moduleMetadata({
       imports: [Tabs, TabsList, TabsTab, TabsPanel, Button, NgIcon],
-      providers: [provideIcons({ phosphorPencilLine, phosphorArrowUpRight })],
+      providers: [provideIcons({ phosphorUsers, phosphorGear })],
     }),
   ],
 }
@@ -53,16 +50,16 @@ export const WithIcons: Story = {
       <ksd-tabs ${argsToTemplate(args)}>
         <ksd-tabs-list>
           <ksd-tabs-tab>
-            <ng-icon name="phosphorPencilLine" />
-            <span>Rediger</span>
+            <ng-icon name="phosphorUsers" />
+            <span>Brukere</span>
           </ksd-tabs-tab>
           <ksd-tabs-tab>
-            <ng-icon name="phosphorArrowUpRight" />
-            <span>Lenker</span>
+            <ng-icon name="phosphorGear" />
+            <span>Innstillinger</span>
           </ksd-tabs-tab>
         </ksd-tabs-list>
-        <ksd-tabs-panel>Innhold for Rediger</ksd-tabs-panel>
-        <ksd-tabs-panel>Innhold for Lenker</ksd-tabs-panel>
+        <ksd-tabs-panel>Innhold for Brukere</ksd-tabs-panel>
+        <ksd-tabs-panel>Innhold for Innstillinger</ksd-tabs-panel>
       </ksd-tabs>
     `,
   }),

--- a/packages/angular/tabs/src/tabs.ts
+++ b/packages/angular/tabs/src/tabs.ts
@@ -28,6 +28,16 @@ import { TabsTab } from './tabs-tab'
       <ng-content select="ksd-tabs-panel" />
     </ds-tabs>
   `,
+  styles: `
+    :host
+      ::ng-deep
+      :is(.ds-tabs [role='tab'], .ds-tabs ds-tab, .ds-tabs u-tab)
+      > :where(ng-icon, svg, img) {
+      font-size: calc(1em * 1.25);
+      width: 1em;
+      height: 1em;
+    }
+  `,
   changeDetection: ChangeDetectionStrategy.OnPush,
   hostDirectives: [
     {


### PR DESCRIPTION
## What is the current behavior?

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Checklist

- [x] 📦 I have updated the public API (for example, if a new component was added)
- [ ] 🧪 Tests - I have added or updated tests that cover my changes (if applicable)
- [x] 📝 Documentation - I have updated relevant documentation, README, or comments (if applicable)
- [ ] 🔗 I have linked all related issues or discussions

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) describes this PR best?
