### PR TITLE
fix(angular): `tabClicked` output

### DIFF
--- a/packages/angular/tabs/src/tabs-tab.ts
+++ b/packages/angular/tabs/src/tabs-tab.ts
@@ -2,6 +2,7 @@ import {
   ChangeDetectionStrategy,
   Component,
   CUSTOM_ELEMENTS_SCHEMA,
+  output,
   TemplateRef,
   viewChild,
 } from '@angular/core'
@@ -29,8 +30,17 @@ import {
 })
 export class TabsTab {
   /**
+   * Emits the tab index when this tab is clicked.
+   */
+  readonly tabClicked = output<number>()
+
+  /**
    * Hack to get the content of the tab from outside so that we can
    * keep the dom structure needed without additional host elements
    */
   templateRef = viewChild<TemplateRef<unknown>>('tpl')
+
+  emitTabClicked(index: number) {
+    this.tabClicked.emit(index)
+  }
 }

--- a/packages/angular/tabs/src/tabs.mdx
+++ b/packages/angular/tabs/src/tabs.mdx
@@ -48,3 +48,22 @@ import {
 })
 export class App {}
 ```
+
+## Reagere på endring
+
+Bruk `tabClicked`-outputen for å lytte etter klikk på tabs.
+
+```ts
+@Component({
+  imports: [Tabs, TabsList, TabsTab, TabsPanel],
+  template: `
+    <ksd-tabs>
+      <ksd-tabs-list>
+        <ksd-tabs-tab (tabClicked)="onTabClicked($event)">Tab 1</ksd-tabs-tab>
+      </ksd-tabs-list>
+      <ksd-tabs-panel>Content 1</ksd-tabs-panel>
+    </ksd-tabs>
+  `,
+})
+export class App {}
+```

--- a/packages/angular/tabs/src/tabs.spec.ts
+++ b/packages/angular/tabs/src/tabs.spec.ts
@@ -22,32 +22,6 @@ describe('Tabs', () => {
     expect(results).toHaveNoViolations()
   })
 
-  it('should emit tabClicked from ksd-tabs when a tab is clicked', async () => {
-    const onTabClicked = vi.fn()
-
-    await render(
-      `
-        <ksd-tabs (tabClicked)="onTabClicked($event)">
-          <ksd-tabs-list>
-            <ksd-tabs-tab>Tab 1</ksd-tabs-tab>
-            <ksd-tabs-tab>Tab 2</ksd-tabs-tab>
-          </ksd-tabs-list>
-          <ksd-tabs-panel>content 1</ksd-tabs-panel>
-          <ksd-tabs-panel>content 2</ksd-tabs-panel>
-        </ksd-tabs>
-      `,
-      {
-        imports: [Tabs, TabsList, TabsTab, TabsPanel],
-        componentProperties: {
-          onTabClicked,
-        },
-      },
-    )
-
-    fireEvent.click(screen.getByText('Tab 2'))
-    expect(onTabClicked).toHaveBeenCalledWith(1)
-  })
-
   it('should emit tabClicked from ksd-tabs-tab when a tab is clicked', async () => {
     const onTabClicked = vi.fn()
 

--- a/packages/angular/tabs/src/tabs.spec.ts
+++ b/packages/angular/tabs/src/tabs.spec.ts
@@ -1,4 +1,5 @@
-import { render } from '@testing-library/angular'
+import { fireEvent, render, screen } from '@testing-library/angular'
+import { vi } from 'vitest'
 import { axe } from 'vitest-axe'
 import { Tabs, TabsList, TabsPanel, TabsTab } from '.'
 
@@ -19,5 +20,57 @@ describe('Tabs', () => {
 
     const results = await axe(container)
     expect(results).toHaveNoViolations()
+  })
+
+  it('should emit tabClicked from ksd-tabs when a tab is clicked', async () => {
+    const onTabClicked = vi.fn()
+
+    await render(
+      `
+        <ksd-tabs (tabClicked)="onTabClicked($event)">
+          <ksd-tabs-list>
+            <ksd-tabs-tab>Tab 1</ksd-tabs-tab>
+            <ksd-tabs-tab>Tab 2</ksd-tabs-tab>
+          </ksd-tabs-list>
+          <ksd-tabs-panel>content 1</ksd-tabs-panel>
+          <ksd-tabs-panel>content 2</ksd-tabs-panel>
+        </ksd-tabs>
+      `,
+      {
+        imports: [Tabs, TabsList, TabsTab, TabsPanel],
+        componentProperties: {
+          onTabClicked,
+        },
+      },
+    )
+
+    fireEvent.click(screen.getByText('Tab 2'))
+    expect(onTabClicked).toHaveBeenCalledWith(1)
+  })
+
+  it('should emit tabClicked from ksd-tabs-tab when a tab is clicked', async () => {
+    const onTabClicked = vi.fn()
+
+    await render(
+      `
+        <ksd-tabs>
+          <ksd-tabs-list>
+            <ksd-tabs-tab (tabClicked)="onTabClicked($event)">Tab 1</ksd-tabs-tab>
+            <ksd-tabs-tab>Tab 2</ksd-tabs-tab>
+          </ksd-tabs-list>
+          <ksd-tabs-panel>content 1</ksd-tabs-panel>
+          <ksd-tabs-panel>content 2</ksd-tabs-panel>
+        </ksd-tabs>
+      `,
+      {
+        imports: [Tabs, TabsList, TabsTab, TabsPanel],
+        componentProperties: {
+          onTabClicked,
+        },
+      },
+    )
+
+    fireEvent.click(screen.getByText('Tab 1'))
+    expect(onTabClicked).toHaveBeenCalledWith(0)
   })
 })

--- a/packages/angular/tabs/src/tabs.ts
+++ b/packages/angular/tabs/src/tabs.ts
@@ -4,6 +4,7 @@ import {
   Component,
   contentChildren,
   CUSTOM_ELEMENTS_SCHEMA,
+  output,
 } from '@angular/core'
 import '@digdir/designsystemet-web'
 import {
@@ -19,8 +20,8 @@ import { TabsTab } from './tabs-tab'
   template: `
     <ds-tabs class="ds-tabs">
       <ds-tablist>
-        @for (tab of tabs(); track tab) {
-          <ds-tab>
+        @for (tab of tabs(); track tab; let index = $index) {
+          <ds-tab (click)="onTabClick(index, tab)">
             <ng-container *ngTemplateOutlet="tab.templateRef()" />
           </ds-tab>
         }
@@ -51,5 +52,15 @@ import { TabsTab } from './tabs-tab'
   ],
 })
 export class Tabs {
+  /**
+   * Emits the tab index when any tab is clicked.
+   */
+  readonly tabClicked = output<number>()
+
   readonly tabs = contentChildren(TabsTab, { descendants: true })
+
+  protected onTabClick(index: number, tab: TabsTab) {
+    this.tabClicked.emit(index)
+    tab.emitTabClicked(index)
+  }
 }

--- a/packages/angular/tabs/src/tabs.ts
+++ b/packages/angular/tabs/src/tabs.ts
@@ -4,7 +4,6 @@ import {
   Component,
   contentChildren,
   CUSTOM_ELEMENTS_SCHEMA,
-  output,
 } from '@angular/core'
 import '@digdir/designsystemet-web'
 import {
@@ -52,15 +51,9 @@ import { TabsTab } from './tabs-tab'
   ],
 })
 export class Tabs {
-  /**
-   * Emits the tab index when any tab is clicked.
-   */
-  readonly tabClicked = output<number>()
-
   readonly tabs = contentChildren(TabsTab, { descendants: true })
 
   protected onTabClick(index: number, tab: TabsTab) {
-    this.tabClicked.emit(index)
     tab.emitTabClicked(index)
   }
 }


### PR DESCRIPTION
## What is the current behavior?
Since we dont render `ksd-tabs-tab` in the dom, attaching a `(click)` listener wont work, since it is the underlying `ds-tab` that gets clicked

## What is the new behavior?
Proxy `ds-tab` click via `ksd-tabs-tab` allows consumers to listen to clicks via the `tabClicked` output


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Checklist

- [x] 📦 I have updated the public API (for example, if a new component was added)
- [x] 🧪 Tests - I have added or updated tests that cover my changes (if applicable)
- [x] 📝 Documentation - I have updated relevant documentation, README, or comments (if applicable)
- [ ] 🔗 I have linked all related issues or discussions

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) describes this PR best?
