### PR TITLE
feat(themes): add custom token for `icon-subtle`

### DIFF
--- a/design-tokens/semantic/color.json
+++ b/design-tokens/semantic/color.json
@@ -43,7 +43,7 @@
       },
       "icon-subtle": {
         "$type": "color",
-        "$value": "{color.accent.10}"
+        "$value": "{color.accent.text-subtle}"
       },
       "text-default": {
         "$type": "color",
@@ -113,7 +113,7 @@
       },
       "icon-subtle": {
         "$type": "color",
-        "$value": "{color.neutral.10}"
+        "$value": "{color.neutral.text-subtle}"
       },
       "text-default": {
         "$type": "color",
@@ -183,7 +183,7 @@
       },
       "icon-subtle": {
         "$type": "color",
-        "$value": "{color.support1.10}"
+        "$value": "{color.support1.text-subtle}"
       },
       "text-default": {
         "$type": "color",
@@ -253,7 +253,7 @@
       },
       "icon-subtle": {
         "$type": "color",
-        "$value": "{color.info.10}"
+        "$value": "{color.info.text-subtle}"
       },
       "text-default": {
         "$type": "color",
@@ -323,7 +323,7 @@
       },
       "icon-subtle": {
         "$type": "color",
-        "$value": "{color.success.10}"
+        "$value": "{color.success.text-subtle}"
       },
       "text-default": {
         "$type": "color",
@@ -393,7 +393,7 @@
       },
       "icon-subtle": {
         "$type": "color",
-        "$value": "{color.warning.10}"
+        "$value": "{color.warning.text-subtle}"
       },
       "text-default": {
         "$type": "color",
@@ -463,7 +463,7 @@
       },
       "icon-subtle": {
         "$type": "color",
-        "$value": "{color.danger.10}"
+        "$value": "{color.danger.text-subtle}"
       },
       "text-default": {
         "$type": "color",

--- a/design-tokens/semantic/color.json
+++ b/design-tokens/semantic/color.json
@@ -41,6 +41,10 @@
         "$type": "color",
         "$value": "{color.accent.10}"
       },
+      "icon-subtle": {
+        "$type": "color",
+        "$value": "{color.accent.10}"
+      },
       "text-default": {
         "$type": "color",
         "$value": "{color.accent.11}"
@@ -104,6 +108,10 @@
         "$value": "{color.neutral.9}"
       },
       "text-subtle": {
+        "$type": "color",
+        "$value": "{color.neutral.10}"
+      },
+      "icon-subtle": {
         "$type": "color",
         "$value": "{color.neutral.10}"
       },
@@ -173,6 +181,10 @@
         "$type": "color",
         "$value": "{color.support1.10}"
       },
+      "icon-subtle": {
+        "$type": "color",
+        "$value": "{color.support1.10}"
+      },
       "text-default": {
         "$type": "color",
         "$value": "{color.support1.11}"
@@ -236,6 +248,10 @@
         "$value": "{color.info.9}"
       },
       "text-subtle": {
+        "$type": "color",
+        "$value": "{color.info.10}"
+      },
+      "icon-subtle": {
         "$type": "color",
         "$value": "{color.info.10}"
       },
@@ -305,6 +321,10 @@
         "$type": "color",
         "$value": "{color.success.10}"
       },
+      "icon-subtle": {
+        "$type": "color",
+        "$value": "{color.success.10}"
+      },
       "text-default": {
         "$type": "color",
         "$value": "{color.success.11}"
@@ -371,6 +391,10 @@
         "$type": "color",
         "$value": "{color.warning.10}"
       },
+      "icon-subtle": {
+        "$type": "color",
+        "$value": "{color.warning.10}"
+      },
       "text-default": {
         "$type": "color",
         "$value": "{color.warning.11}"
@@ -434,6 +458,10 @@
         "$value": "{color.danger.9}"
       },
       "text-subtle": {
+        "$type": "color",
+        "$value": "{color.danger.10}"
+      },
+      "icon-subtle": {
         "$type": "color",
         "$value": "{color.danger.10}"
       },

--- a/design-tokens/semantic/modes/main-color/accent.json
+++ b/design-tokens/semantic/modes/main-color/accent.json
@@ -43,7 +43,7 @@
       },
       "icon-subtle": {
         "$type": "color",
-        "$value": "{color.accent.text-subtle}"
+        "$value": "{color.accent.icon-subtle}"
       },
       "text-default": {
         "$type": "color",

--- a/design-tokens/semantic/modes/main-color/accent.json
+++ b/design-tokens/semantic/modes/main-color/accent.json
@@ -43,7 +43,7 @@
       },
       "icon-subtle": {
         "$type": "color",
-        "$value": "{color.accent.icon-subtle}"
+        "$value": "{color.main.text-subtle}"
       },
       "text-default": {
         "$type": "color",

--- a/design-tokens/semantic/modes/main-color/accent.json
+++ b/design-tokens/semantic/modes/main-color/accent.json
@@ -41,6 +41,10 @@
         "$type": "color",
         "$value": "{color.accent.text-subtle}"
       },
+      "icon-subtle": {
+        "$type": "color",
+        "$value": "{color.accent.text-subtle}"
+      },
       "text-default": {
         "$type": "color",
         "$value": "{color.accent.text-default}"

--- a/design-tokens/semantic/modes/support-color/support1.json
+++ b/design-tokens/semantic/modes/support-color/support1.json
@@ -43,7 +43,7 @@
       },
       "icon-subtle": {
         "$type": "color",
-        "$value": "{color.support1.text-subtle}"
+        "$value": "{color.support1.icon-subtle}"
       },
       "text-default": {
         "$type": "color",

--- a/design-tokens/semantic/modes/support-color/support1.json
+++ b/design-tokens/semantic/modes/support-color/support1.json
@@ -43,7 +43,7 @@
       },
       "icon-subtle": {
         "$type": "color",
-        "$value": "{color.support1.icon-subtle}"
+        "$value": "{color.support.text-subtle}"
       },
       "text-default": {
         "$type": "color",

--- a/design-tokens/semantic/modes/support-color/support1.json
+++ b/design-tokens/semantic/modes/support-color/support1.json
@@ -41,6 +41,10 @@
         "$type": "color",
         "$value": "{color.support1.text-subtle}"
       },
+      "icon-subtle": {
+        "$type": "color",
+        "$value": "{color.support1.text-subtle}"
+      },
       "text-default": {
         "$type": "color",
         "$value": "{color.support1.text-default}"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
     "format": "prettier --write .",
     "preinstall": "npx only-allow pnpm",
     "prepare": "husky",
-    "themes:apply-custom-tokens": "node ./tools/apply-custom-tokens.mjs all",
     "themes:apply-custom-tokens:tokens": "node ./tools/apply-custom-tokens.mjs tokens",
     "themes:apply-custom-tokens:outputs": "node ./tools/apply-custom-tokens.mjs outputs",
     "themes:create-tokens": "./node_modules/.bin/designsystemet tokens create --config designsystemet.config.json",

--- a/package.json
+++ b/package.json
@@ -8,8 +8,10 @@
     "format": "prettier --write .",
     "preinstall": "npx only-allow pnpm",
     "prepare": "husky",
+    "themes:apply-custom-tokens": "node ./tools/apply-custom-tokens.mjs",
     "themes:create-tokens": "./node_modules/.bin/designsystemet tokens create --config designsystemet.config.json",
-    "themes:build": "./node_modules/.bin/designsystemet tokens build --experimental-tailwind --out-dir packages/themes/src/themes"
+    "themes:build": "./node_modules/.bin/designsystemet tokens build --experimental-tailwind --out-dir packages/themes/src/themes",
+    "themes:generate": "pnpm themes:create-tokens && pnpm themes:apply-custom-tokens && pnpm themes:build"
   },
   "lint-staged": {
     "*.{ts,tsx,mts,html,scss,json,yml,yaml,md}": [

--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
     "prepare": "husky",
     "themes:apply-custom-tokens": "node ./tools/apply-custom-tokens.mjs",
     "themes:create-tokens": "./node_modules/.bin/designsystemet tokens create --config designsystemet.config.json",
-    "themes:build": "./node_modules/.bin/designsystemet tokens build --experimental-tailwind --out-dir packages/themes/src/themes",
-    "themes:generate": "pnpm themes:create-tokens && pnpm themes:apply-custom-tokens && pnpm themes:build"
+    "themes:build": "./node_modules/.bin/designsystemet tokens build --experimental-tailwind --out-dir packages/themes/src/themes && node ./tools/apply-custom-tokens.mjs",
+    "themes:generate": "pnpm themes:create-tokens && pnpm themes:build"
   },
   "lint-staged": {
     "*.{ts,tsx,mts,html,scss,json,yml,yaml,md}": [

--- a/package.json
+++ b/package.json
@@ -8,9 +8,11 @@
     "format": "prettier --write .",
     "preinstall": "npx only-allow pnpm",
     "prepare": "husky",
-    "themes:apply-custom-tokens": "node ./tools/apply-custom-tokens.mjs",
+    "themes:apply-custom-tokens": "node ./tools/apply-custom-tokens.mjs all",
+    "themes:apply-custom-tokens:tokens": "node ./tools/apply-custom-tokens.mjs tokens",
+    "themes:apply-custom-tokens:outputs": "node ./tools/apply-custom-tokens.mjs outputs",
     "themes:create-tokens": "./node_modules/.bin/designsystemet tokens create --config designsystemet.config.json",
-    "themes:build": "./node_modules/.bin/designsystemet tokens build --experimental-tailwind --out-dir packages/themes/src/themes && node ./tools/apply-custom-tokens.mjs",
+    "themes:build": "pnpm themes:apply-custom-tokens:tokens && ./node_modules/.bin/designsystemet tokens build --experimental-tailwind --out-dir packages/themes/src/themes && pnpm themes:apply-custom-tokens:outputs",
     "themes:generate": "pnpm themes:create-tokens && pnpm themes:build"
   },
   "lint-staged": {

--- a/packages/themes/README.md
+++ b/packages/themes/README.md
@@ -75,8 +75,11 @@ import '@ks-digital/designsystem-themes/ledsagerbevis.css'
 
 1. Add theme to `designsystemet.config.json`. The color names must match the other themes.
 2. Create design tokens for theme `pnpm run themes:create-tokens`
-3. Apply KS custom token aliases `pnpm run themes:apply-custom-tokens`
-4. Build themes `pnpm run themes:build`
+3. Apply KS custom token aliases to the generated token sources `pnpm run themes:apply-custom-tokens:tokens`
+4. Build themes `pnpm run themes:build`.
+   This also applies KS custom token aliases to the generated theme outputs via `themes:apply-custom-tokens:outputs`.
 5. Add theme `exports`-field in `packages/themes/package.json`
 6. Add theme to Storybook `tools/storybook/themes.ts`
 7. Add theme to docs `apps/www/src/Temaer.mdx`
+
+For the full pipeline, you can also run `pnpm run themes:generate`.

--- a/packages/themes/README.md
+++ b/packages/themes/README.md
@@ -75,7 +75,8 @@ import '@ks-digital/designsystem-themes/ledsagerbevis.css'
 
 1. Add theme to `designsystemet.config.json`. The color names must match the other themes.
 2. Create design tokens for theme `pnpm run themes:create-tokens`
-3. Build themes `pnpm run themes:build`
-4. Add theme `exports`-field in `packages/themes/package.json`
-5. Add theme to Storybook `tools/storybook/themes.ts`
-6. Add theme to docs `apps/www/src/Temaer.mdx`
+3. Apply KS custom token aliases `pnpm run themes:apply-custom-tokens`
+4. Build themes `pnpm run themes:build`
+5. Add theme `exports`-field in `packages/themes/package.json`
+6. Add theme to Storybook `tools/storybook/themes.ts`
+7. Add theme to docs `apps/www/src/Temaer.mdx`

--- a/packages/themes/src/themes/ksdigital.css
+++ b/packages/themes/src/themes/ksdigital.css
@@ -1,6 +1,7 @@
 @charset "UTF-8";
 /*
 build: v1.12.1
+design-tokens: v1.12.1
 */
 
 @layer ds.theme.size-mode {
@@ -128,7 +129,6 @@ build: v1.12.1
     --ds-color-accent-border-default: #75778e;
     --ds-color-accent-border-strong: #595b77;
     --ds-color-accent-text-subtle: #595b77;
-    --ds-color-accent-icon-subtle: #595b77;
     --ds-color-accent-text-default: #25284c;
     --ds-color-accent-base-default: #00042e;
     --ds-color-accent-base-hover: #151940;
@@ -145,7 +145,6 @@ build: v1.12.1
     --ds-color-neutral-border-default: #74797e;
     --ds-color-neutral-border-strong: #585e64;
     --ds-color-neutral-text-subtle: #585e64;
-    --ds-color-neutral-icon-subtle: #585e64;
     --ds-color-neutral-text-default: #242c34;
     --ds-color-neutral-base-default: #1d252d;
     --ds-color-neutral-base-hover: #2f363d;
@@ -162,7 +161,6 @@ build: v1.12.1
     --ds-color-support1-border-default: #8060ec;
     --ds-color-support1-border-strong: #6244cb;
     --ds-color-support1-text-subtle: #6244cb;
-    --ds-color-support1-icon-subtle: #6244cb;
     --ds-color-support1-text-default: #2e2060;
     --ds-color-support1-base-default: #714eea;
     --ds-color-support1-base-hover: #5d40c0;
@@ -179,7 +177,6 @@ build: v1.12.1
     --ds-color-info-border-default: #1f7dc5;
     --ds-color-info-border-strong: #0860a3;
     --ds-color-info-text-subtle: #0860a3;
-    --ds-color-info-icon-subtle: #0860a3;
     --ds-color-info-text-default: #042d4d;
     --ds-color-info-base-default: #0a71c0;
     --ds-color-info-base-hover: #085d9f;
@@ -196,7 +193,6 @@ build: v1.12.1
     --ds-color-success-border-default: #108c22;
     --ds-color-success-border-strong: #056d13;
     --ds-color-success-text-subtle: #056d13;
-    --ds-color-success-icon-subtle: #056d13;
     --ds-color-success-text-default: #023409;
     --ds-color-success-base-default: #068718;
     --ds-color-success-base-hover: #057014;
@@ -213,7 +209,6 @@ build: v1.12.1
     --ds-color-warning-border-default: #a56d13;
     --ds-color-warning-border-strong: #80540f;
     --ds-color-warning-text-subtle: #80540f;
-    --ds-color-warning-icon-subtle: #80540f;
     --ds-color-warning-text-default: #3c2807;
     --ds-color-warning-base-default: #ea9b1b;
     --ds-color-warning-base-hover: #cd8818;
@@ -230,7 +225,6 @@ build: v1.12.1
     --ds-color-danger-border-default: #ce4d4d;
     --ds-color-danger-border-strong: #b81a1a;
     --ds-color-danger-text-subtle: #b81a1a;
-    --ds-color-danger-icon-subtle: #b81a1a;
     --ds-color-danger-text-default: #590d0d;
     --ds-color-danger-base-default: #c01b1b;
     --ds-color-danger-base-hover: #9b1616;
@@ -256,7 +250,6 @@ build: v1.12.1
       --ds-color-accent-border-default: #75778e;
       --ds-color-accent-border-strong: #595b77;
       --ds-color-accent-text-subtle: #595b77;
-      --ds-color-accent-icon-subtle: #595b77;
       --ds-color-accent-text-default: #25284c;
       --ds-color-accent-base-default: #00042e;
       --ds-color-accent-base-hover: #151940;
@@ -273,7 +266,6 @@ build: v1.12.1
       --ds-color-neutral-border-default: #74797e;
       --ds-color-neutral-border-strong: #585e64;
       --ds-color-neutral-text-subtle: #585e64;
-      --ds-color-neutral-icon-subtle: #585e64;
       --ds-color-neutral-text-default: #242c34;
       --ds-color-neutral-base-default: #1d252d;
       --ds-color-neutral-base-hover: #2f363d;
@@ -290,7 +282,6 @@ build: v1.12.1
       --ds-color-support1-border-default: #8060ec;
       --ds-color-support1-border-strong: #6244cb;
       --ds-color-support1-text-subtle: #6244cb;
-      --ds-color-support1-icon-subtle: #6244cb;
       --ds-color-support1-text-default: #2e2060;
       --ds-color-support1-base-default: #714eea;
       --ds-color-support1-base-hover: #5d40c0;
@@ -307,7 +298,6 @@ build: v1.12.1
       --ds-color-info-border-default: #1f7dc5;
       --ds-color-info-border-strong: #0860a3;
       --ds-color-info-text-subtle: #0860a3;
-      --ds-color-info-icon-subtle: #0860a3;
       --ds-color-info-text-default: #042d4d;
       --ds-color-info-base-default: #0a71c0;
       --ds-color-info-base-hover: #085d9f;
@@ -324,7 +314,6 @@ build: v1.12.1
       --ds-color-success-border-default: #108c22;
       --ds-color-success-border-strong: #056d13;
       --ds-color-success-text-subtle: #056d13;
-      --ds-color-success-icon-subtle: #056d13;
       --ds-color-success-text-default: #023409;
       --ds-color-success-base-default: #068718;
       --ds-color-success-base-hover: #057014;
@@ -341,7 +330,6 @@ build: v1.12.1
       --ds-color-warning-border-default: #a56d13;
       --ds-color-warning-border-strong: #80540f;
       --ds-color-warning-text-subtle: #80540f;
-      --ds-color-warning-icon-subtle: #80540f;
       --ds-color-warning-text-default: #3c2807;
       --ds-color-warning-base-default: #ea9b1b;
       --ds-color-warning-base-hover: #cd8818;
@@ -358,7 +346,6 @@ build: v1.12.1
       --ds-color-danger-border-default: #ce4d4d;
       --ds-color-danger-border-strong: #b81a1a;
       --ds-color-danger-text-subtle: #b81a1a;
-      --ds-color-danger-icon-subtle: #b81a1a;
       --ds-color-danger-text-default: #590d0d;
       --ds-color-danger-base-default: #c01b1b;
       --ds-color-danger-base-hover: #9b1616;
@@ -570,7 +557,6 @@ build: v1.12.1
     --ds-color-accent-border-default: #7e818f;
     --ds-color-accent-border-strong: #a5a7b1;
     --ds-color-accent-text-subtle: #a5a7b1;
-    --ds-color-accent-icon-subtle: #a5a7b1;
     --ds-color-accent-text-default: #ececee;
     --ds-color-accent-base-default: #a9aab8;
     --ds-color-accent-base-hover: #9395a7;
@@ -587,7 +573,6 @@ build: v1.12.1
     --ds-color-neutral-border-default: #7e8285;
     --ds-color-neutral-border-strong: #a6a8aa;
     --ds-color-neutral-text-subtle: #a6a8aa;
-    --ds-color-neutral-icon-subtle: #a6a8aa;
     --ds-color-neutral-text-default: #ececed;
     --ds-color-neutral-base-default: #a8abae;
     --ds-color-neutral-base-hover: #93979a;
@@ -604,7 +589,6 @@ build: v1.12.1
     --ds-color-support1-border-default: #8375cf;
     --ds-color-support1-border-strong: #aaa0de;
     --ds-color-support1-text-subtle: #aaa0de;
-    --ds-color-support1-icon-subtle: #aaa0de;
     --ds-color-support1-text-default: #edebf8;
     --ds-color-support1-base-default: #896cee;
     --ds-color-support1-base-hover: #9f87f1;
@@ -621,7 +605,6 @@ build: v1.12.1
     --ds-color-info-border-default: #5585b4;
     --ds-color-info-border-strong: #8aabcb;
     --ds-color-info-text-subtle: #8aabcb;
-    --ds-color-info-icon-subtle: #8aabcb;
     --ds-color-info-text-default: #e6edf4;
     --ds-color-info-base-default: #2d85c9;
     --ds-color-info-base-hover: #519ad2;
@@ -638,7 +621,6 @@ build: v1.12.1
     --ds-color-success-border-default: #528f52;
     --ds-color-success-border-strong: #89b289;
     --ds-color-success-text-subtle: #89b289;
-    --ds-color-success-icon-subtle: #89b289;
     --ds-color-success-text-default: #e6efe6;
     --ds-color-success-base-default: #138d24;
     --ds-color-success-base-hover: #3ca14b;
@@ -655,7 +637,6 @@ build: v1.12.1
     --ds-color-warning-border-default: #a37a46;
     --ds-color-warning-border-strong: #d39e5b;
     --ds-color-warning-text-subtle: #d39e5b;
-    --ds-color-warning-icon-subtle: #d39e5b;
     --ds-color-warning-text-default: #f7ebdb;
     --ds-color-warning-base-default: #60400b;
     --ds-color-warning-base-hover: #7a510e;
@@ -672,7 +653,6 @@ build: v1.12.1
     --ds-color-danger-border-default: #bc6b64;
     --ds-color-danger-border-strong: #d19a96;
     --ds-color-danger-text-subtle: #d19a96;
-    --ds-color-danger-icon-subtle: #d19a96;
     --ds-color-danger-text-default: #f5eae9;
     --ds-color-danger-base-default: #d76e6e;
     --ds-color-danger-base-hover: #df8b8b;
@@ -698,7 +678,6 @@ build: v1.12.1
       --ds-color-accent-border-default: #7e818f;
       --ds-color-accent-border-strong: #a5a7b1;
       --ds-color-accent-text-subtle: #a5a7b1;
-      --ds-color-accent-icon-subtle: #a5a7b1;
       --ds-color-accent-text-default: #ececee;
       --ds-color-accent-base-default: #a9aab8;
       --ds-color-accent-base-hover: #9395a7;
@@ -715,7 +694,6 @@ build: v1.12.1
       --ds-color-neutral-border-default: #7e8285;
       --ds-color-neutral-border-strong: #a6a8aa;
       --ds-color-neutral-text-subtle: #a6a8aa;
-      --ds-color-neutral-icon-subtle: #a6a8aa;
       --ds-color-neutral-text-default: #ececed;
       --ds-color-neutral-base-default: #a8abae;
       --ds-color-neutral-base-hover: #93979a;
@@ -732,7 +710,6 @@ build: v1.12.1
       --ds-color-support1-border-default: #8375cf;
       --ds-color-support1-border-strong: #aaa0de;
       --ds-color-support1-text-subtle: #aaa0de;
-      --ds-color-support1-icon-subtle: #aaa0de;
       --ds-color-support1-text-default: #edebf8;
       --ds-color-support1-base-default: #896cee;
       --ds-color-support1-base-hover: #9f87f1;
@@ -749,7 +726,6 @@ build: v1.12.1
       --ds-color-info-border-default: #5585b4;
       --ds-color-info-border-strong: #8aabcb;
       --ds-color-info-text-subtle: #8aabcb;
-      --ds-color-info-icon-subtle: #8aabcb;
       --ds-color-info-text-default: #e6edf4;
       --ds-color-info-base-default: #2d85c9;
       --ds-color-info-base-hover: #519ad2;
@@ -766,7 +742,6 @@ build: v1.12.1
       --ds-color-success-border-default: #528f52;
       --ds-color-success-border-strong: #89b289;
       --ds-color-success-text-subtle: #89b289;
-      --ds-color-success-icon-subtle: #89b289;
       --ds-color-success-text-default: #e6efe6;
       --ds-color-success-base-default: #138d24;
       --ds-color-success-base-hover: #3ca14b;
@@ -783,7 +758,6 @@ build: v1.12.1
       --ds-color-warning-border-default: #a37a46;
       --ds-color-warning-border-strong: #d39e5b;
       --ds-color-warning-text-subtle: #d39e5b;
-      --ds-color-warning-icon-subtle: #d39e5b;
       --ds-color-warning-text-default: #f7ebdb;
       --ds-color-warning-base-default: #60400b;
       --ds-color-warning-base-hover: #7a510e;
@@ -800,7 +774,6 @@ build: v1.12.1
       --ds-color-danger-border-default: #bc6b64;
       --ds-color-danger-border-strong: #d19a96;
       --ds-color-danger-text-subtle: #d19a96;
-      --ds-color-danger-icon-subtle: #d19a96;
       --ds-color-danger-text-default: #f5eae9;
       --ds-color-danger-base-default: #d76e6e;
       --ds-color-danger-base-hover: #df8b8b;
@@ -917,7 +890,6 @@ build: v1.12.1
     --ds-color-border-default: var(--ds-color-accent-border-default);
     --ds-color-border-strong: var(--ds-color-accent-border-strong);
     --ds-color-text-subtle: var(--ds-color-accent-text-subtle);
-    --ds-color-icon-subtle: var(--ds-color-accent-icon-subtle);
     --ds-color-text-default: var(--ds-color-accent-text-default);
     --ds-color-base-default: var(--ds-color-accent-base-default);
     --ds-color-base-hover: var(--ds-color-accent-base-hover);
@@ -944,7 +916,6 @@ build: v1.12.1
     --ds-color-border-default: var(--ds-color-danger-border-default);
     --ds-color-border-strong: var(--ds-color-danger-border-strong);
     --ds-color-text-subtle: var(--ds-color-danger-text-subtle);
-    --ds-color-icon-subtle: var(--ds-color-danger-icon-subtle);
     --ds-color-text-default: var(--ds-color-danger-text-default);
     --ds-color-base-default: var(--ds-color-danger-base-default);
     --ds-color-base-hover: var(--ds-color-danger-base-hover);
@@ -971,7 +942,6 @@ build: v1.12.1
     --ds-color-border-default: var(--ds-color-info-border-default);
     --ds-color-border-strong: var(--ds-color-info-border-strong);
     --ds-color-text-subtle: var(--ds-color-info-text-subtle);
-    --ds-color-icon-subtle: var(--ds-color-info-icon-subtle);
     --ds-color-text-default: var(--ds-color-info-text-default);
     --ds-color-base-default: var(--ds-color-info-base-default);
     --ds-color-base-hover: var(--ds-color-info-base-hover);
@@ -996,7 +966,6 @@ build: v1.12.1
     --ds-color-border-default: var(--ds-color-neutral-border-default);
     --ds-color-border-strong: var(--ds-color-neutral-border-strong);
     --ds-color-text-subtle: var(--ds-color-neutral-text-subtle);
-    --ds-color-icon-subtle: var(--ds-color-neutral-icon-subtle);
     --ds-color-text-default: var(--ds-color-neutral-text-default);
     --ds-color-base-default: var(--ds-color-neutral-base-default);
     --ds-color-base-hover: var(--ds-color-neutral-base-hover);
@@ -1023,7 +992,6 @@ build: v1.12.1
     --ds-color-border-default: var(--ds-color-success-border-default);
     --ds-color-border-strong: var(--ds-color-success-border-strong);
     --ds-color-text-subtle: var(--ds-color-success-text-subtle);
-    --ds-color-icon-subtle: var(--ds-color-success-icon-subtle);
     --ds-color-text-default: var(--ds-color-success-text-default);
     --ds-color-base-default: var(--ds-color-success-base-default);
     --ds-color-base-hover: var(--ds-color-success-base-hover);
@@ -1050,7 +1018,6 @@ build: v1.12.1
     --ds-color-border-default: var(--ds-color-support1-border-default);
     --ds-color-border-strong: var(--ds-color-support1-border-strong);
     --ds-color-text-subtle: var(--ds-color-support1-text-subtle);
-    --ds-color-icon-subtle: var(--ds-color-support1-icon-subtle);
     --ds-color-text-default: var(--ds-color-support1-text-default);
     --ds-color-base-default: var(--ds-color-support1-base-default);
     --ds-color-base-hover: var(--ds-color-support1-base-hover);
@@ -1077,7 +1044,6 @@ build: v1.12.1
     --ds-color-border-default: var(--ds-color-warning-border-default);
     --ds-color-border-strong: var(--ds-color-warning-border-strong);
     --ds-color-text-subtle: var(--ds-color-warning-text-subtle);
-    --ds-color-icon-subtle: var(--ds-color-warning-icon-subtle);
     --ds-color-text-default: var(--ds-color-warning-text-default);
     --ds-color-base-default: var(--ds-color-warning-base-default);
     --ds-color-base-hover: var(--ds-color-warning-base-hover);

--- a/packages/themes/src/themes/ksdigital.css
+++ b/packages/themes/src/themes/ksdigital.css
@@ -917,7 +917,7 @@ build: v1.12.1
     --ds-color-border-default: var(--ds-color-accent-border-default);
     --ds-color-border-strong: var(--ds-color-accent-border-strong);
     --ds-color-text-subtle: var(--ds-color-accent-text-subtle);
-    --ds-color-icon-subtle: var(--ds-color-accent-text-subtle);
+    --ds-color-icon-subtle: var(--ds-color-accent-icon-subtle);
     --ds-color-text-default: var(--ds-color-accent-text-default);
     --ds-color-base-default: var(--ds-color-accent-base-default);
     --ds-color-base-hover: var(--ds-color-accent-base-hover);
@@ -1050,7 +1050,7 @@ build: v1.12.1
     --ds-color-border-default: var(--ds-color-support1-border-default);
     --ds-color-border-strong: var(--ds-color-support1-border-strong);
     --ds-color-text-subtle: var(--ds-color-support1-text-subtle);
-    --ds-color-icon-subtle: var(--ds-color-support1-text-subtle);
+    --ds-color-icon-subtle: var(--ds-color-support1-icon-subtle);
     --ds-color-text-default: var(--ds-color-support1-text-default);
     --ds-color-base-default: var(--ds-color-support1-base-default);
     --ds-color-base-hover: var(--ds-color-support1-base-hover);

--- a/packages/themes/src/themes/ksdigital.css
+++ b/packages/themes/src/themes/ksdigital.css
@@ -1,7 +1,6 @@
 @charset "UTF-8";
 /*
 build: v1.12.1
-design-tokens: v1.12.1
 */
 
 @layer ds.theme.size-mode {
@@ -129,6 +128,7 @@ design-tokens: v1.12.1
     --ds-color-accent-border-default: #75778e;
     --ds-color-accent-border-strong: #595b77;
     --ds-color-accent-text-subtle: #595b77;
+    --ds-color-accent-icon-subtle: #595b77;
     --ds-color-accent-text-default: #25284c;
     --ds-color-accent-base-default: #00042e;
     --ds-color-accent-base-hover: #151940;
@@ -145,6 +145,7 @@ design-tokens: v1.12.1
     --ds-color-neutral-border-default: #74797e;
     --ds-color-neutral-border-strong: #585e64;
     --ds-color-neutral-text-subtle: #585e64;
+    --ds-color-neutral-icon-subtle: #585e64;
     --ds-color-neutral-text-default: #242c34;
     --ds-color-neutral-base-default: #1d252d;
     --ds-color-neutral-base-hover: #2f363d;
@@ -161,6 +162,7 @@ design-tokens: v1.12.1
     --ds-color-support1-border-default: #8060ec;
     --ds-color-support1-border-strong: #6244cb;
     --ds-color-support1-text-subtle: #6244cb;
+    --ds-color-support1-icon-subtle: #6244cb;
     --ds-color-support1-text-default: #2e2060;
     --ds-color-support1-base-default: #714eea;
     --ds-color-support1-base-hover: #5d40c0;
@@ -177,6 +179,7 @@ design-tokens: v1.12.1
     --ds-color-info-border-default: #1f7dc5;
     --ds-color-info-border-strong: #0860a3;
     --ds-color-info-text-subtle: #0860a3;
+    --ds-color-info-icon-subtle: #0860a3;
     --ds-color-info-text-default: #042d4d;
     --ds-color-info-base-default: #0a71c0;
     --ds-color-info-base-hover: #085d9f;
@@ -193,6 +196,7 @@ design-tokens: v1.12.1
     --ds-color-success-border-default: #108c22;
     --ds-color-success-border-strong: #056d13;
     --ds-color-success-text-subtle: #056d13;
+    --ds-color-success-icon-subtle: #056d13;
     --ds-color-success-text-default: #023409;
     --ds-color-success-base-default: #068718;
     --ds-color-success-base-hover: #057014;
@@ -209,6 +213,7 @@ design-tokens: v1.12.1
     --ds-color-warning-border-default: #a56d13;
     --ds-color-warning-border-strong: #80540f;
     --ds-color-warning-text-subtle: #80540f;
+    --ds-color-warning-icon-subtle: #80540f;
     --ds-color-warning-text-default: #3c2807;
     --ds-color-warning-base-default: #ea9b1b;
     --ds-color-warning-base-hover: #cd8818;
@@ -225,6 +230,7 @@ design-tokens: v1.12.1
     --ds-color-danger-border-default: #ce4d4d;
     --ds-color-danger-border-strong: #b81a1a;
     --ds-color-danger-text-subtle: #b81a1a;
+    --ds-color-danger-icon-subtle: #b81a1a;
     --ds-color-danger-text-default: #590d0d;
     --ds-color-danger-base-default: #c01b1b;
     --ds-color-danger-base-hover: #9b1616;
@@ -250,6 +256,7 @@ design-tokens: v1.12.1
       --ds-color-accent-border-default: #75778e;
       --ds-color-accent-border-strong: #595b77;
       --ds-color-accent-text-subtle: #595b77;
+      --ds-color-accent-icon-subtle: #595b77;
       --ds-color-accent-text-default: #25284c;
       --ds-color-accent-base-default: #00042e;
       --ds-color-accent-base-hover: #151940;
@@ -266,6 +273,7 @@ design-tokens: v1.12.1
       --ds-color-neutral-border-default: #74797e;
       --ds-color-neutral-border-strong: #585e64;
       --ds-color-neutral-text-subtle: #585e64;
+      --ds-color-neutral-icon-subtle: #585e64;
       --ds-color-neutral-text-default: #242c34;
       --ds-color-neutral-base-default: #1d252d;
       --ds-color-neutral-base-hover: #2f363d;
@@ -282,6 +290,7 @@ design-tokens: v1.12.1
       --ds-color-support1-border-default: #8060ec;
       --ds-color-support1-border-strong: #6244cb;
       --ds-color-support1-text-subtle: #6244cb;
+      --ds-color-support1-icon-subtle: #6244cb;
       --ds-color-support1-text-default: #2e2060;
       --ds-color-support1-base-default: #714eea;
       --ds-color-support1-base-hover: #5d40c0;
@@ -298,6 +307,7 @@ design-tokens: v1.12.1
       --ds-color-info-border-default: #1f7dc5;
       --ds-color-info-border-strong: #0860a3;
       --ds-color-info-text-subtle: #0860a3;
+      --ds-color-info-icon-subtle: #0860a3;
       --ds-color-info-text-default: #042d4d;
       --ds-color-info-base-default: #0a71c0;
       --ds-color-info-base-hover: #085d9f;
@@ -314,6 +324,7 @@ design-tokens: v1.12.1
       --ds-color-success-border-default: #108c22;
       --ds-color-success-border-strong: #056d13;
       --ds-color-success-text-subtle: #056d13;
+      --ds-color-success-icon-subtle: #056d13;
       --ds-color-success-text-default: #023409;
       --ds-color-success-base-default: #068718;
       --ds-color-success-base-hover: #057014;
@@ -330,6 +341,7 @@ design-tokens: v1.12.1
       --ds-color-warning-border-default: #a56d13;
       --ds-color-warning-border-strong: #80540f;
       --ds-color-warning-text-subtle: #80540f;
+      --ds-color-warning-icon-subtle: #80540f;
       --ds-color-warning-text-default: #3c2807;
       --ds-color-warning-base-default: #ea9b1b;
       --ds-color-warning-base-hover: #cd8818;
@@ -346,6 +358,7 @@ design-tokens: v1.12.1
       --ds-color-danger-border-default: #ce4d4d;
       --ds-color-danger-border-strong: #b81a1a;
       --ds-color-danger-text-subtle: #b81a1a;
+      --ds-color-danger-icon-subtle: #b81a1a;
       --ds-color-danger-text-default: #590d0d;
       --ds-color-danger-base-default: #c01b1b;
       --ds-color-danger-base-hover: #9b1616;
@@ -557,6 +570,7 @@ design-tokens: v1.12.1
     --ds-color-accent-border-default: #7e818f;
     --ds-color-accent-border-strong: #a5a7b1;
     --ds-color-accent-text-subtle: #a5a7b1;
+    --ds-color-accent-icon-subtle: #a5a7b1;
     --ds-color-accent-text-default: #ececee;
     --ds-color-accent-base-default: #a9aab8;
     --ds-color-accent-base-hover: #9395a7;
@@ -573,6 +587,7 @@ design-tokens: v1.12.1
     --ds-color-neutral-border-default: #7e8285;
     --ds-color-neutral-border-strong: #a6a8aa;
     --ds-color-neutral-text-subtle: #a6a8aa;
+    --ds-color-neutral-icon-subtle: #a6a8aa;
     --ds-color-neutral-text-default: #ececed;
     --ds-color-neutral-base-default: #a8abae;
     --ds-color-neutral-base-hover: #93979a;
@@ -589,6 +604,7 @@ design-tokens: v1.12.1
     --ds-color-support1-border-default: #8375cf;
     --ds-color-support1-border-strong: #aaa0de;
     --ds-color-support1-text-subtle: #aaa0de;
+    --ds-color-support1-icon-subtle: #aaa0de;
     --ds-color-support1-text-default: #edebf8;
     --ds-color-support1-base-default: #896cee;
     --ds-color-support1-base-hover: #9f87f1;
@@ -605,6 +621,7 @@ design-tokens: v1.12.1
     --ds-color-info-border-default: #5585b4;
     --ds-color-info-border-strong: #8aabcb;
     --ds-color-info-text-subtle: #8aabcb;
+    --ds-color-info-icon-subtle: #8aabcb;
     --ds-color-info-text-default: #e6edf4;
     --ds-color-info-base-default: #2d85c9;
     --ds-color-info-base-hover: #519ad2;
@@ -621,6 +638,7 @@ design-tokens: v1.12.1
     --ds-color-success-border-default: #528f52;
     --ds-color-success-border-strong: #89b289;
     --ds-color-success-text-subtle: #89b289;
+    --ds-color-success-icon-subtle: #89b289;
     --ds-color-success-text-default: #e6efe6;
     --ds-color-success-base-default: #138d24;
     --ds-color-success-base-hover: #3ca14b;
@@ -637,6 +655,7 @@ design-tokens: v1.12.1
     --ds-color-warning-border-default: #a37a46;
     --ds-color-warning-border-strong: #d39e5b;
     --ds-color-warning-text-subtle: #d39e5b;
+    --ds-color-warning-icon-subtle: #d39e5b;
     --ds-color-warning-text-default: #f7ebdb;
     --ds-color-warning-base-default: #60400b;
     --ds-color-warning-base-hover: #7a510e;
@@ -653,6 +672,7 @@ design-tokens: v1.12.1
     --ds-color-danger-border-default: #bc6b64;
     --ds-color-danger-border-strong: #d19a96;
     --ds-color-danger-text-subtle: #d19a96;
+    --ds-color-danger-icon-subtle: #d19a96;
     --ds-color-danger-text-default: #f5eae9;
     --ds-color-danger-base-default: #d76e6e;
     --ds-color-danger-base-hover: #df8b8b;
@@ -678,6 +698,7 @@ design-tokens: v1.12.1
       --ds-color-accent-border-default: #7e818f;
       --ds-color-accent-border-strong: #a5a7b1;
       --ds-color-accent-text-subtle: #a5a7b1;
+      --ds-color-accent-icon-subtle: #a5a7b1;
       --ds-color-accent-text-default: #ececee;
       --ds-color-accent-base-default: #a9aab8;
       --ds-color-accent-base-hover: #9395a7;
@@ -694,6 +715,7 @@ design-tokens: v1.12.1
       --ds-color-neutral-border-default: #7e8285;
       --ds-color-neutral-border-strong: #a6a8aa;
       --ds-color-neutral-text-subtle: #a6a8aa;
+      --ds-color-neutral-icon-subtle: #a6a8aa;
       --ds-color-neutral-text-default: #ececed;
       --ds-color-neutral-base-default: #a8abae;
       --ds-color-neutral-base-hover: #93979a;
@@ -710,6 +732,7 @@ design-tokens: v1.12.1
       --ds-color-support1-border-default: #8375cf;
       --ds-color-support1-border-strong: #aaa0de;
       --ds-color-support1-text-subtle: #aaa0de;
+      --ds-color-support1-icon-subtle: #aaa0de;
       --ds-color-support1-text-default: #edebf8;
       --ds-color-support1-base-default: #896cee;
       --ds-color-support1-base-hover: #9f87f1;
@@ -726,6 +749,7 @@ design-tokens: v1.12.1
       --ds-color-info-border-default: #5585b4;
       --ds-color-info-border-strong: #8aabcb;
       --ds-color-info-text-subtle: #8aabcb;
+      --ds-color-info-icon-subtle: #8aabcb;
       --ds-color-info-text-default: #e6edf4;
       --ds-color-info-base-default: #2d85c9;
       --ds-color-info-base-hover: #519ad2;
@@ -742,6 +766,7 @@ design-tokens: v1.12.1
       --ds-color-success-border-default: #528f52;
       --ds-color-success-border-strong: #89b289;
       --ds-color-success-text-subtle: #89b289;
+      --ds-color-success-icon-subtle: #89b289;
       --ds-color-success-text-default: #e6efe6;
       --ds-color-success-base-default: #138d24;
       --ds-color-success-base-hover: #3ca14b;
@@ -758,6 +783,7 @@ design-tokens: v1.12.1
       --ds-color-warning-border-default: #a37a46;
       --ds-color-warning-border-strong: #d39e5b;
       --ds-color-warning-text-subtle: #d39e5b;
+      --ds-color-warning-icon-subtle: #d39e5b;
       --ds-color-warning-text-default: #f7ebdb;
       --ds-color-warning-base-default: #60400b;
       --ds-color-warning-base-hover: #7a510e;
@@ -774,6 +800,7 @@ design-tokens: v1.12.1
       --ds-color-danger-border-default: #bc6b64;
       --ds-color-danger-border-strong: #d19a96;
       --ds-color-danger-text-subtle: #d19a96;
+      --ds-color-danger-icon-subtle: #d19a96;
       --ds-color-danger-text-default: #f5eae9;
       --ds-color-danger-base-default: #d76e6e;
       --ds-color-danger-base-hover: #df8b8b;
@@ -890,6 +917,7 @@ design-tokens: v1.12.1
     --ds-color-border-default: var(--ds-color-accent-border-default);
     --ds-color-border-strong: var(--ds-color-accent-border-strong);
     --ds-color-text-subtle: var(--ds-color-accent-text-subtle);
+    --ds-color-icon-subtle: var(--ds-color-accent-text-subtle);
     --ds-color-text-default: var(--ds-color-accent-text-default);
     --ds-color-base-default: var(--ds-color-accent-base-default);
     --ds-color-base-hover: var(--ds-color-accent-base-hover);
@@ -916,6 +944,7 @@ design-tokens: v1.12.1
     --ds-color-border-default: var(--ds-color-danger-border-default);
     --ds-color-border-strong: var(--ds-color-danger-border-strong);
     --ds-color-text-subtle: var(--ds-color-danger-text-subtle);
+    --ds-color-icon-subtle: var(--ds-color-danger-icon-subtle);
     --ds-color-text-default: var(--ds-color-danger-text-default);
     --ds-color-base-default: var(--ds-color-danger-base-default);
     --ds-color-base-hover: var(--ds-color-danger-base-hover);
@@ -942,6 +971,7 @@ design-tokens: v1.12.1
     --ds-color-border-default: var(--ds-color-info-border-default);
     --ds-color-border-strong: var(--ds-color-info-border-strong);
     --ds-color-text-subtle: var(--ds-color-info-text-subtle);
+    --ds-color-icon-subtle: var(--ds-color-info-icon-subtle);
     --ds-color-text-default: var(--ds-color-info-text-default);
     --ds-color-base-default: var(--ds-color-info-base-default);
     --ds-color-base-hover: var(--ds-color-info-base-hover);
@@ -966,6 +996,7 @@ design-tokens: v1.12.1
     --ds-color-border-default: var(--ds-color-neutral-border-default);
     --ds-color-border-strong: var(--ds-color-neutral-border-strong);
     --ds-color-text-subtle: var(--ds-color-neutral-text-subtle);
+    --ds-color-icon-subtle: var(--ds-color-neutral-icon-subtle);
     --ds-color-text-default: var(--ds-color-neutral-text-default);
     --ds-color-base-default: var(--ds-color-neutral-base-default);
     --ds-color-base-hover: var(--ds-color-neutral-base-hover);
@@ -992,6 +1023,7 @@ design-tokens: v1.12.1
     --ds-color-border-default: var(--ds-color-success-border-default);
     --ds-color-border-strong: var(--ds-color-success-border-strong);
     --ds-color-text-subtle: var(--ds-color-success-text-subtle);
+    --ds-color-icon-subtle: var(--ds-color-success-icon-subtle);
     --ds-color-text-default: var(--ds-color-success-text-default);
     --ds-color-base-default: var(--ds-color-success-base-default);
     --ds-color-base-hover: var(--ds-color-success-base-hover);
@@ -1018,6 +1050,7 @@ design-tokens: v1.12.1
     --ds-color-border-default: var(--ds-color-support1-border-default);
     --ds-color-border-strong: var(--ds-color-support1-border-strong);
     --ds-color-text-subtle: var(--ds-color-support1-text-subtle);
+    --ds-color-icon-subtle: var(--ds-color-support1-text-subtle);
     --ds-color-text-default: var(--ds-color-support1-text-default);
     --ds-color-base-default: var(--ds-color-support1-base-default);
     --ds-color-base-hover: var(--ds-color-support1-base-hover);
@@ -1044,6 +1077,7 @@ design-tokens: v1.12.1
     --ds-color-border-default: var(--ds-color-warning-border-default);
     --ds-color-border-strong: var(--ds-color-warning-border-strong);
     --ds-color-text-subtle: var(--ds-color-warning-text-subtle);
+    --ds-color-icon-subtle: var(--ds-color-warning-icon-subtle);
     --ds-color-text-default: var(--ds-color-warning-text-default);
     --ds-color-base-default: var(--ds-color-warning-base-default);
     --ds-color-base-hover: var(--ds-color-warning-base-hover);

--- a/packages/themes/src/themes/ksdigital.css
+++ b/packages/themes/src/themes/ksdigital.css
@@ -129,6 +129,7 @@ design-tokens: v1.12.1
     --ds-color-accent-border-default: #75778e;
     --ds-color-accent-border-strong: #595b77;
     --ds-color-accent-text-subtle: #595b77;
+    --ds-color-accent-icon-subtle: #595b77;
     --ds-color-accent-text-default: #25284c;
     --ds-color-accent-base-default: #00042e;
     --ds-color-accent-base-hover: #151940;
@@ -145,6 +146,7 @@ design-tokens: v1.12.1
     --ds-color-neutral-border-default: #74797e;
     --ds-color-neutral-border-strong: #585e64;
     --ds-color-neutral-text-subtle: #585e64;
+    --ds-color-neutral-icon-subtle: #585e64;
     --ds-color-neutral-text-default: #242c34;
     --ds-color-neutral-base-default: #1d252d;
     --ds-color-neutral-base-hover: #2f363d;
@@ -161,6 +163,7 @@ design-tokens: v1.12.1
     --ds-color-support1-border-default: #8060ec;
     --ds-color-support1-border-strong: #6244cb;
     --ds-color-support1-text-subtle: #6244cb;
+    --ds-color-support1-icon-subtle: #6244cb;
     --ds-color-support1-text-default: #2e2060;
     --ds-color-support1-base-default: #714eea;
     --ds-color-support1-base-hover: #5d40c0;
@@ -177,6 +180,7 @@ design-tokens: v1.12.1
     --ds-color-info-border-default: #1f7dc5;
     --ds-color-info-border-strong: #0860a3;
     --ds-color-info-text-subtle: #0860a3;
+    --ds-color-info-icon-subtle: #0860a3;
     --ds-color-info-text-default: #042d4d;
     --ds-color-info-base-default: #0a71c0;
     --ds-color-info-base-hover: #085d9f;
@@ -193,6 +197,7 @@ design-tokens: v1.12.1
     --ds-color-success-border-default: #108c22;
     --ds-color-success-border-strong: #056d13;
     --ds-color-success-text-subtle: #056d13;
+    --ds-color-success-icon-subtle: #056d13;
     --ds-color-success-text-default: #023409;
     --ds-color-success-base-default: #068718;
     --ds-color-success-base-hover: #057014;
@@ -209,6 +214,7 @@ design-tokens: v1.12.1
     --ds-color-warning-border-default: #a56d13;
     --ds-color-warning-border-strong: #80540f;
     --ds-color-warning-text-subtle: #80540f;
+    --ds-color-warning-icon-subtle: #80540f;
     --ds-color-warning-text-default: #3c2807;
     --ds-color-warning-base-default: #ea9b1b;
     --ds-color-warning-base-hover: #cd8818;
@@ -225,6 +231,7 @@ design-tokens: v1.12.1
     --ds-color-danger-border-default: #ce4d4d;
     --ds-color-danger-border-strong: #b81a1a;
     --ds-color-danger-text-subtle: #b81a1a;
+    --ds-color-danger-icon-subtle: #b81a1a;
     --ds-color-danger-text-default: #590d0d;
     --ds-color-danger-base-default: #c01b1b;
     --ds-color-danger-base-hover: #9b1616;
@@ -250,6 +257,7 @@ design-tokens: v1.12.1
       --ds-color-accent-border-default: #75778e;
       --ds-color-accent-border-strong: #595b77;
       --ds-color-accent-text-subtle: #595b77;
+      --ds-color-accent-icon-subtle: #595b77;
       --ds-color-accent-text-default: #25284c;
       --ds-color-accent-base-default: #00042e;
       --ds-color-accent-base-hover: #151940;
@@ -266,6 +274,7 @@ design-tokens: v1.12.1
       --ds-color-neutral-border-default: #74797e;
       --ds-color-neutral-border-strong: #585e64;
       --ds-color-neutral-text-subtle: #585e64;
+      --ds-color-neutral-icon-subtle: #585e64;
       --ds-color-neutral-text-default: #242c34;
       --ds-color-neutral-base-default: #1d252d;
       --ds-color-neutral-base-hover: #2f363d;
@@ -282,6 +291,7 @@ design-tokens: v1.12.1
       --ds-color-support1-border-default: #8060ec;
       --ds-color-support1-border-strong: #6244cb;
       --ds-color-support1-text-subtle: #6244cb;
+      --ds-color-support1-icon-subtle: #6244cb;
       --ds-color-support1-text-default: #2e2060;
       --ds-color-support1-base-default: #714eea;
       --ds-color-support1-base-hover: #5d40c0;
@@ -298,6 +308,7 @@ design-tokens: v1.12.1
       --ds-color-info-border-default: #1f7dc5;
       --ds-color-info-border-strong: #0860a3;
       --ds-color-info-text-subtle: #0860a3;
+      --ds-color-info-icon-subtle: #0860a3;
       --ds-color-info-text-default: #042d4d;
       --ds-color-info-base-default: #0a71c0;
       --ds-color-info-base-hover: #085d9f;
@@ -314,6 +325,7 @@ design-tokens: v1.12.1
       --ds-color-success-border-default: #108c22;
       --ds-color-success-border-strong: #056d13;
       --ds-color-success-text-subtle: #056d13;
+      --ds-color-success-icon-subtle: #056d13;
       --ds-color-success-text-default: #023409;
       --ds-color-success-base-default: #068718;
       --ds-color-success-base-hover: #057014;
@@ -330,6 +342,7 @@ design-tokens: v1.12.1
       --ds-color-warning-border-default: #a56d13;
       --ds-color-warning-border-strong: #80540f;
       --ds-color-warning-text-subtle: #80540f;
+      --ds-color-warning-icon-subtle: #80540f;
       --ds-color-warning-text-default: #3c2807;
       --ds-color-warning-base-default: #ea9b1b;
       --ds-color-warning-base-hover: #cd8818;
@@ -346,6 +359,7 @@ design-tokens: v1.12.1
       --ds-color-danger-border-default: #ce4d4d;
       --ds-color-danger-border-strong: #b81a1a;
       --ds-color-danger-text-subtle: #b81a1a;
+      --ds-color-danger-icon-subtle: #b81a1a;
       --ds-color-danger-text-default: #590d0d;
       --ds-color-danger-base-default: #c01b1b;
       --ds-color-danger-base-hover: #9b1616;
@@ -557,6 +571,7 @@ design-tokens: v1.12.1
     --ds-color-accent-border-default: #7e818f;
     --ds-color-accent-border-strong: #a5a7b1;
     --ds-color-accent-text-subtle: #a5a7b1;
+    --ds-color-accent-icon-subtle: #a5a7b1;
     --ds-color-accent-text-default: #ececee;
     --ds-color-accent-base-default: #a9aab8;
     --ds-color-accent-base-hover: #9395a7;
@@ -573,6 +588,7 @@ design-tokens: v1.12.1
     --ds-color-neutral-border-default: #7e8285;
     --ds-color-neutral-border-strong: #a6a8aa;
     --ds-color-neutral-text-subtle: #a6a8aa;
+    --ds-color-neutral-icon-subtle: #a6a8aa;
     --ds-color-neutral-text-default: #ececed;
     --ds-color-neutral-base-default: #a8abae;
     --ds-color-neutral-base-hover: #93979a;
@@ -589,6 +605,7 @@ design-tokens: v1.12.1
     --ds-color-support1-border-default: #8375cf;
     --ds-color-support1-border-strong: #aaa0de;
     --ds-color-support1-text-subtle: #aaa0de;
+    --ds-color-support1-icon-subtle: #aaa0de;
     --ds-color-support1-text-default: #edebf8;
     --ds-color-support1-base-default: #896cee;
     --ds-color-support1-base-hover: #9f87f1;
@@ -605,6 +622,7 @@ design-tokens: v1.12.1
     --ds-color-info-border-default: #5585b4;
     --ds-color-info-border-strong: #8aabcb;
     --ds-color-info-text-subtle: #8aabcb;
+    --ds-color-info-icon-subtle: #8aabcb;
     --ds-color-info-text-default: #e6edf4;
     --ds-color-info-base-default: #2d85c9;
     --ds-color-info-base-hover: #519ad2;
@@ -621,6 +639,7 @@ design-tokens: v1.12.1
     --ds-color-success-border-default: #528f52;
     --ds-color-success-border-strong: #89b289;
     --ds-color-success-text-subtle: #89b289;
+    --ds-color-success-icon-subtle: #89b289;
     --ds-color-success-text-default: #e6efe6;
     --ds-color-success-base-default: #138d24;
     --ds-color-success-base-hover: #3ca14b;
@@ -637,6 +656,7 @@ design-tokens: v1.12.1
     --ds-color-warning-border-default: #a37a46;
     --ds-color-warning-border-strong: #d39e5b;
     --ds-color-warning-text-subtle: #d39e5b;
+    --ds-color-warning-icon-subtle: #d39e5b;
     --ds-color-warning-text-default: #f7ebdb;
     --ds-color-warning-base-default: #60400b;
     --ds-color-warning-base-hover: #7a510e;
@@ -653,6 +673,7 @@ design-tokens: v1.12.1
     --ds-color-danger-border-default: #bc6b64;
     --ds-color-danger-border-strong: #d19a96;
     --ds-color-danger-text-subtle: #d19a96;
+    --ds-color-danger-icon-subtle: #d19a96;
     --ds-color-danger-text-default: #f5eae9;
     --ds-color-danger-base-default: #d76e6e;
     --ds-color-danger-base-hover: #df8b8b;
@@ -678,6 +699,7 @@ design-tokens: v1.12.1
       --ds-color-accent-border-default: #7e818f;
       --ds-color-accent-border-strong: #a5a7b1;
       --ds-color-accent-text-subtle: #a5a7b1;
+      --ds-color-accent-icon-subtle: #a5a7b1;
       --ds-color-accent-text-default: #ececee;
       --ds-color-accent-base-default: #a9aab8;
       --ds-color-accent-base-hover: #9395a7;
@@ -694,6 +716,7 @@ design-tokens: v1.12.1
       --ds-color-neutral-border-default: #7e8285;
       --ds-color-neutral-border-strong: #a6a8aa;
       --ds-color-neutral-text-subtle: #a6a8aa;
+      --ds-color-neutral-icon-subtle: #a6a8aa;
       --ds-color-neutral-text-default: #ececed;
       --ds-color-neutral-base-default: #a8abae;
       --ds-color-neutral-base-hover: #93979a;
@@ -710,6 +733,7 @@ design-tokens: v1.12.1
       --ds-color-support1-border-default: #8375cf;
       --ds-color-support1-border-strong: #aaa0de;
       --ds-color-support1-text-subtle: #aaa0de;
+      --ds-color-support1-icon-subtle: #aaa0de;
       --ds-color-support1-text-default: #edebf8;
       --ds-color-support1-base-default: #896cee;
       --ds-color-support1-base-hover: #9f87f1;
@@ -726,6 +750,7 @@ design-tokens: v1.12.1
       --ds-color-info-border-default: #5585b4;
       --ds-color-info-border-strong: #8aabcb;
       --ds-color-info-text-subtle: #8aabcb;
+      --ds-color-info-icon-subtle: #8aabcb;
       --ds-color-info-text-default: #e6edf4;
       --ds-color-info-base-default: #2d85c9;
       --ds-color-info-base-hover: #519ad2;
@@ -742,6 +767,7 @@ design-tokens: v1.12.1
       --ds-color-success-border-default: #528f52;
       --ds-color-success-border-strong: #89b289;
       --ds-color-success-text-subtle: #89b289;
+      --ds-color-success-icon-subtle: #89b289;
       --ds-color-success-text-default: #e6efe6;
       --ds-color-success-base-default: #138d24;
       --ds-color-success-base-hover: #3ca14b;
@@ -758,6 +784,7 @@ design-tokens: v1.12.1
       --ds-color-warning-border-default: #a37a46;
       --ds-color-warning-border-strong: #d39e5b;
       --ds-color-warning-text-subtle: #d39e5b;
+      --ds-color-warning-icon-subtle: #d39e5b;
       --ds-color-warning-text-default: #f7ebdb;
       --ds-color-warning-base-default: #60400b;
       --ds-color-warning-base-hover: #7a510e;
@@ -774,6 +801,7 @@ design-tokens: v1.12.1
       --ds-color-danger-border-default: #bc6b64;
       --ds-color-danger-border-strong: #d19a96;
       --ds-color-danger-text-subtle: #d19a96;
+      --ds-color-danger-icon-subtle: #d19a96;
       --ds-color-danger-text-default: #f5eae9;
       --ds-color-danger-base-default: #d76e6e;
       --ds-color-danger-base-hover: #df8b8b;
@@ -890,6 +918,7 @@ design-tokens: v1.12.1
     --ds-color-border-default: var(--ds-color-accent-border-default);
     --ds-color-border-strong: var(--ds-color-accent-border-strong);
     --ds-color-text-subtle: var(--ds-color-accent-text-subtle);
+    --ds-color-icon-subtle: var(--ds-color-accent-icon-subtle);
     --ds-color-text-default: var(--ds-color-accent-text-default);
     --ds-color-base-default: var(--ds-color-accent-base-default);
     --ds-color-base-hover: var(--ds-color-accent-base-hover);
@@ -916,6 +945,7 @@ design-tokens: v1.12.1
     --ds-color-border-default: var(--ds-color-danger-border-default);
     --ds-color-border-strong: var(--ds-color-danger-border-strong);
     --ds-color-text-subtle: var(--ds-color-danger-text-subtle);
+    --ds-color-icon-subtle: var(--ds-color-danger-icon-subtle);
     --ds-color-text-default: var(--ds-color-danger-text-default);
     --ds-color-base-default: var(--ds-color-danger-base-default);
     --ds-color-base-hover: var(--ds-color-danger-base-hover);
@@ -942,6 +972,7 @@ design-tokens: v1.12.1
     --ds-color-border-default: var(--ds-color-info-border-default);
     --ds-color-border-strong: var(--ds-color-info-border-strong);
     --ds-color-text-subtle: var(--ds-color-info-text-subtle);
+    --ds-color-icon-subtle: var(--ds-color-info-icon-subtle);
     --ds-color-text-default: var(--ds-color-info-text-default);
     --ds-color-base-default: var(--ds-color-info-base-default);
     --ds-color-base-hover: var(--ds-color-info-base-hover);
@@ -966,6 +997,7 @@ design-tokens: v1.12.1
     --ds-color-border-default: var(--ds-color-neutral-border-default);
     --ds-color-border-strong: var(--ds-color-neutral-border-strong);
     --ds-color-text-subtle: var(--ds-color-neutral-text-subtle);
+    --ds-color-icon-subtle: var(--ds-color-neutral-icon-subtle);
     --ds-color-text-default: var(--ds-color-neutral-text-default);
     --ds-color-base-default: var(--ds-color-neutral-base-default);
     --ds-color-base-hover: var(--ds-color-neutral-base-hover);
@@ -992,6 +1024,7 @@ design-tokens: v1.12.1
     --ds-color-border-default: var(--ds-color-success-border-default);
     --ds-color-border-strong: var(--ds-color-success-border-strong);
     --ds-color-text-subtle: var(--ds-color-success-text-subtle);
+    --ds-color-icon-subtle: var(--ds-color-success-icon-subtle);
     --ds-color-text-default: var(--ds-color-success-text-default);
     --ds-color-base-default: var(--ds-color-success-base-default);
     --ds-color-base-hover: var(--ds-color-success-base-hover);
@@ -1018,6 +1051,7 @@ design-tokens: v1.12.1
     --ds-color-border-default: var(--ds-color-support1-border-default);
     --ds-color-border-strong: var(--ds-color-support1-border-strong);
     --ds-color-text-subtle: var(--ds-color-support1-text-subtle);
+    --ds-color-icon-subtle: var(--ds-color-support1-icon-subtle);
     --ds-color-text-default: var(--ds-color-support1-text-default);
     --ds-color-base-default: var(--ds-color-support1-base-default);
     --ds-color-base-hover: var(--ds-color-support1-base-hover);
@@ -1044,6 +1078,7 @@ design-tokens: v1.12.1
     --ds-color-border-default: var(--ds-color-warning-border-default);
     --ds-color-border-strong: var(--ds-color-warning-border-strong);
     --ds-color-text-subtle: var(--ds-color-warning-text-subtle);
+    --ds-color-icon-subtle: var(--ds-color-warning-icon-subtle);
     --ds-color-text-default: var(--ds-color-warning-text-default);
     --ds-color-base-default: var(--ds-color-warning-base-default);
     --ds-color-base-hover: var(--ds-color-warning-base-hover);

--- a/packages/themes/src/themes/ksdigital.tailwind.css
+++ b/packages/themes/src/themes/ksdigital.tailwind.css
@@ -18,6 +18,7 @@
   --color-accent-border-default: var(--ds-color-accent-border-default);
   --color-accent-border-strong: var(--ds-color-accent-border-strong);
   --color-accent-border-subtle: var(--ds-color-accent-border-subtle);
+  --color-accent-icon-subtle: var(--ds-color-accent-icon-subtle);
   --color-accent-surface-active: var(--ds-color-accent-surface-active);
   --color-accent-surface-default: var(--ds-color-accent-surface-default);
   --color-accent-surface-hover: var(--ds-color-accent-surface-hover);
@@ -48,12 +49,14 @@
   --color-danger-border-default: var(--ds-color-danger-border-default);
   --color-danger-border-strong: var(--ds-color-danger-border-strong);
   --color-danger-border-subtle: var(--ds-color-danger-border-subtle);
+  --color-danger-icon-subtle: var(--ds-color-danger-icon-subtle);
   --color-danger-surface-active: var(--ds-color-danger-surface-active);
   --color-danger-surface-default: var(--ds-color-danger-surface-default);
   --color-danger-surface-hover: var(--ds-color-danger-surface-hover);
   --color-danger-surface-tinted: var(--ds-color-danger-surface-tinted);
   --color-danger-text-default: var(--ds-color-danger-text-default);
   --color-danger-text-subtle: var(--ds-color-danger-text-subtle);
+  --color-icon-subtle: var(--ds-color-icon-subtle);
   --color-info-background-default: var(--ds-color-info-background-default);
   --color-info-background-tinted: var(--ds-color-info-background-tinted);
   --color-info-base-active: var(--ds-color-info-base-active);
@@ -66,6 +69,7 @@
   --color-info-border-default: var(--ds-color-info-border-default);
   --color-info-border-strong: var(--ds-color-info-border-strong);
   --color-info-border-subtle: var(--ds-color-info-border-subtle);
+  --color-info-icon-subtle: var(--ds-color-info-icon-subtle);
   --color-info-surface-active: var(--ds-color-info-surface-active);
   --color-info-surface-default: var(--ds-color-info-surface-default);
   --color-info-surface-hover: var(--ds-color-info-surface-hover);
@@ -88,6 +92,7 @@
   --color-neutral-border-default: var(--ds-color-neutral-border-default);
   --color-neutral-border-strong: var(--ds-color-neutral-border-strong);
   --color-neutral-border-subtle: var(--ds-color-neutral-border-subtle);
+  --color-neutral-icon-subtle: var(--ds-color-neutral-icon-subtle);
   --color-neutral-surface-active: var(--ds-color-neutral-surface-active);
   --color-neutral-surface-default: var(--ds-color-neutral-surface-default);
   --color-neutral-surface-hover: var(--ds-color-neutral-surface-hover);
@@ -110,6 +115,7 @@
   --color-success-border-default: var(--ds-color-success-border-default);
   --color-success-border-strong: var(--ds-color-success-border-strong);
   --color-success-border-subtle: var(--ds-color-success-border-subtle);
+  --color-success-icon-subtle: var(--ds-color-success-icon-subtle);
   --color-success-surface-active: var(--ds-color-success-surface-active);
   --color-success-surface-default: var(--ds-color-success-surface-default);
   --color-success-surface-hover: var(--ds-color-success-surface-hover);
@@ -134,6 +140,7 @@
   --color-support1-border-default: var(--ds-color-support1-border-default);
   --color-support1-border-strong: var(--ds-color-support1-border-strong);
   --color-support1-border-subtle: var(--ds-color-support1-border-subtle);
+  --color-support1-icon-subtle: var(--ds-color-support1-icon-subtle);
   --color-support1-surface-active: var(--ds-color-support1-surface-active);
   --color-support1-surface-default: var(--ds-color-support1-surface-default);
   --color-support1-surface-hover: var(--ds-color-support1-surface-hover);
@@ -162,6 +169,7 @@
   --color-warning-border-default: var(--ds-color-warning-border-default);
   --color-warning-border-strong: var(--ds-color-warning-border-strong);
   --color-warning-border-subtle: var(--ds-color-warning-border-subtle);
+  --color-warning-icon-subtle: var(--ds-color-warning-icon-subtle);
   --color-warning-surface-active: var(--ds-color-warning-surface-active);
   --color-warning-surface-default: var(--ds-color-warning-surface-default);
   --color-warning-surface-hover: var(--ds-color-warning-surface-hover);

--- a/packages/themes/src/themes/ksdigital.tailwind.css
+++ b/packages/themes/src/themes/ksdigital.tailwind.css
@@ -18,7 +18,6 @@
   --color-accent-border-default: var(--ds-color-accent-border-default);
   --color-accent-border-strong: var(--ds-color-accent-border-strong);
   --color-accent-border-subtle: var(--ds-color-accent-border-subtle);
-  --color-accent-icon-subtle: var(--ds-color-accent-icon-subtle);
   --color-accent-surface-active: var(--ds-color-accent-surface-active);
   --color-accent-surface-default: var(--ds-color-accent-surface-default);
   --color-accent-surface-hover: var(--ds-color-accent-surface-hover);
@@ -49,14 +48,12 @@
   --color-danger-border-default: var(--ds-color-danger-border-default);
   --color-danger-border-strong: var(--ds-color-danger-border-strong);
   --color-danger-border-subtle: var(--ds-color-danger-border-subtle);
-  --color-danger-icon-subtle: var(--ds-color-danger-icon-subtle);
   --color-danger-surface-active: var(--ds-color-danger-surface-active);
   --color-danger-surface-default: var(--ds-color-danger-surface-default);
   --color-danger-surface-hover: var(--ds-color-danger-surface-hover);
   --color-danger-surface-tinted: var(--ds-color-danger-surface-tinted);
   --color-danger-text-default: var(--ds-color-danger-text-default);
   --color-danger-text-subtle: var(--ds-color-danger-text-subtle);
-  --color-icon-subtle: var(--ds-color-icon-subtle);
   --color-info-background-default: var(--ds-color-info-background-default);
   --color-info-background-tinted: var(--ds-color-info-background-tinted);
   --color-info-base-active: var(--ds-color-info-base-active);
@@ -69,7 +66,6 @@
   --color-info-border-default: var(--ds-color-info-border-default);
   --color-info-border-strong: var(--ds-color-info-border-strong);
   --color-info-border-subtle: var(--ds-color-info-border-subtle);
-  --color-info-icon-subtle: var(--ds-color-info-icon-subtle);
   --color-info-surface-active: var(--ds-color-info-surface-active);
   --color-info-surface-default: var(--ds-color-info-surface-default);
   --color-info-surface-hover: var(--ds-color-info-surface-hover);
@@ -92,7 +88,6 @@
   --color-neutral-border-default: var(--ds-color-neutral-border-default);
   --color-neutral-border-strong: var(--ds-color-neutral-border-strong);
   --color-neutral-border-subtle: var(--ds-color-neutral-border-subtle);
-  --color-neutral-icon-subtle: var(--ds-color-neutral-icon-subtle);
   --color-neutral-surface-active: var(--ds-color-neutral-surface-active);
   --color-neutral-surface-default: var(--ds-color-neutral-surface-default);
   --color-neutral-surface-hover: var(--ds-color-neutral-surface-hover);
@@ -115,7 +110,6 @@
   --color-success-border-default: var(--ds-color-success-border-default);
   --color-success-border-strong: var(--ds-color-success-border-strong);
   --color-success-border-subtle: var(--ds-color-success-border-subtle);
-  --color-success-icon-subtle: var(--ds-color-success-icon-subtle);
   --color-success-surface-active: var(--ds-color-success-surface-active);
   --color-success-surface-default: var(--ds-color-success-surface-default);
   --color-success-surface-hover: var(--ds-color-success-surface-hover);
@@ -140,7 +134,6 @@
   --color-support1-border-default: var(--ds-color-support1-border-default);
   --color-support1-border-strong: var(--ds-color-support1-border-strong);
   --color-support1-border-subtle: var(--ds-color-support1-border-subtle);
-  --color-support1-icon-subtle: var(--ds-color-support1-icon-subtle);
   --color-support1-surface-active: var(--ds-color-support1-surface-active);
   --color-support1-surface-default: var(--ds-color-support1-surface-default);
   --color-support1-surface-hover: var(--ds-color-support1-surface-hover);
@@ -169,7 +162,6 @@
   --color-warning-border-default: var(--ds-color-warning-border-default);
   --color-warning-border-strong: var(--ds-color-warning-border-strong);
   --color-warning-border-subtle: var(--ds-color-warning-border-subtle);
-  --color-warning-icon-subtle: var(--ds-color-warning-icon-subtle);
   --color-warning-surface-active: var(--ds-color-warning-surface-active);
   --color-warning-surface-default: var(--ds-color-warning-surface-default);
   --color-warning-surface-hover: var(--ds-color-warning-surface-hover);
@@ -211,6 +203,7 @@
   --color-border-default: var(--ds-color-border-default);
   --color-border-strong: var(--ds-color-border-strong);
   --color-text-subtle: var(--ds-color-text-subtle);
+  --color-icon-subtle: var(--ds-color-icon-subtle);
   --color-text-default: var(--ds-color-text-default);
   --color-base-default: var(--ds-color-base-default);
   --color-base-hover: var(--ds-color-base-hover);

--- a/packages/themes/src/themes/ledsagerbevis.css
+++ b/packages/themes/src/themes/ledsagerbevis.css
@@ -129,6 +129,7 @@ design-tokens: v1.12.1
     --ds-color-accent-border-default: #627f76;
     --ds-color-accent-border-strong: #416459;
     --ds-color-accent-text-subtle: #416459;
+    --ds-color-accent-icon-subtle: #416459;
     --ds-color-accent-text-default: #193029;
     --ds-color-accent-base-default: #2b5246;
     --ds-color-accent-base-hover: #213f35;
@@ -145,6 +146,7 @@ design-tokens: v1.12.1
     --ds-color-neutral-border-default: #767978;
     --ds-color-neutral-border-strong: #5a5e5d;
     --ds-color-neutral-text-subtle: #5a5e5d;
+    --ds-color-neutral-icon-subtle: #5a5e5d;
     --ds-color-neutral-text-default: #272d2b;
     --ds-color-neutral-base-default: #1e2422;
     --ds-color-neutral-base-hover: #303533;
@@ -161,6 +163,7 @@ design-tokens: v1.12.1
     --ds-color-support1-border-default: #158967;
     --ds-color-support1-border-strong: #106a50;
     --ds-color-support1-text-subtle: #106a50;
+    --ds-color-support1-icon-subtle: #106a50;
     --ds-color-support1-text-default: #083225;
     --ds-color-support1-base-default: #1aa87e;
     --ds-color-support1-base-hover: #4dbb9b;
@@ -177,6 +180,7 @@ design-tokens: v1.12.1
     --ds-color-info-border-default: #1f7dc5;
     --ds-color-info-border-strong: #0860a3;
     --ds-color-info-text-subtle: #0860a3;
+    --ds-color-info-icon-subtle: #0860a3;
     --ds-color-info-text-default: #042d4d;
     --ds-color-info-base-default: #0a71c0;
     --ds-color-info-base-hover: #085d9f;
@@ -193,6 +197,7 @@ design-tokens: v1.12.1
     --ds-color-success-border-default: #108c22;
     --ds-color-success-border-strong: #056d13;
     --ds-color-success-text-subtle: #056d13;
+    --ds-color-success-icon-subtle: #056d13;
     --ds-color-success-text-default: #023409;
     --ds-color-success-base-default: #068718;
     --ds-color-success-base-hover: #057014;
@@ -209,6 +214,7 @@ design-tokens: v1.12.1
     --ds-color-warning-border-default: #a56d13;
     --ds-color-warning-border-strong: #80540f;
     --ds-color-warning-text-subtle: #80540f;
+    --ds-color-warning-icon-subtle: #80540f;
     --ds-color-warning-text-default: #3c2807;
     --ds-color-warning-base-default: #ea9b1b;
     --ds-color-warning-base-hover: #cd8818;
@@ -225,6 +231,7 @@ design-tokens: v1.12.1
     --ds-color-danger-border-default: #ce4d4d;
     --ds-color-danger-border-strong: #b81a1a;
     --ds-color-danger-text-subtle: #b81a1a;
+    --ds-color-danger-icon-subtle: #b81a1a;
     --ds-color-danger-text-default: #590d0d;
     --ds-color-danger-base-default: #c01b1b;
     --ds-color-danger-base-hover: #9b1616;
@@ -250,6 +257,7 @@ design-tokens: v1.12.1
       --ds-color-accent-border-default: #627f76;
       --ds-color-accent-border-strong: #416459;
       --ds-color-accent-text-subtle: #416459;
+      --ds-color-accent-icon-subtle: #416459;
       --ds-color-accent-text-default: #193029;
       --ds-color-accent-base-default: #2b5246;
       --ds-color-accent-base-hover: #213f35;
@@ -266,6 +274,7 @@ design-tokens: v1.12.1
       --ds-color-neutral-border-default: #767978;
       --ds-color-neutral-border-strong: #5a5e5d;
       --ds-color-neutral-text-subtle: #5a5e5d;
+      --ds-color-neutral-icon-subtle: #5a5e5d;
       --ds-color-neutral-text-default: #272d2b;
       --ds-color-neutral-base-default: #1e2422;
       --ds-color-neutral-base-hover: #303533;
@@ -282,6 +291,7 @@ design-tokens: v1.12.1
       --ds-color-support1-border-default: #158967;
       --ds-color-support1-border-strong: #106a50;
       --ds-color-support1-text-subtle: #106a50;
+      --ds-color-support1-icon-subtle: #106a50;
       --ds-color-support1-text-default: #083225;
       --ds-color-support1-base-default: #1aa87e;
       --ds-color-support1-base-hover: #4dbb9b;
@@ -298,6 +308,7 @@ design-tokens: v1.12.1
       --ds-color-info-border-default: #1f7dc5;
       --ds-color-info-border-strong: #0860a3;
       --ds-color-info-text-subtle: #0860a3;
+      --ds-color-info-icon-subtle: #0860a3;
       --ds-color-info-text-default: #042d4d;
       --ds-color-info-base-default: #0a71c0;
       --ds-color-info-base-hover: #085d9f;
@@ -314,6 +325,7 @@ design-tokens: v1.12.1
       --ds-color-success-border-default: #108c22;
       --ds-color-success-border-strong: #056d13;
       --ds-color-success-text-subtle: #056d13;
+      --ds-color-success-icon-subtle: #056d13;
       --ds-color-success-text-default: #023409;
       --ds-color-success-base-default: #068718;
       --ds-color-success-base-hover: #057014;
@@ -330,6 +342,7 @@ design-tokens: v1.12.1
       --ds-color-warning-border-default: #a56d13;
       --ds-color-warning-border-strong: #80540f;
       --ds-color-warning-text-subtle: #80540f;
+      --ds-color-warning-icon-subtle: #80540f;
       --ds-color-warning-text-default: #3c2807;
       --ds-color-warning-base-default: #ea9b1b;
       --ds-color-warning-base-hover: #cd8818;
@@ -346,6 +359,7 @@ design-tokens: v1.12.1
       --ds-color-danger-border-default: #ce4d4d;
       --ds-color-danger-border-strong: #b81a1a;
       --ds-color-danger-text-subtle: #b81a1a;
+      --ds-color-danger-icon-subtle: #b81a1a;
       --ds-color-danger-text-default: #590d0d;
       --ds-color-danger-base-default: #c01b1b;
       --ds-color-danger-base-hover: #9b1616;
@@ -557,6 +571,7 @@ design-tokens: v1.12.1
     --ds-color-accent-border-default: #74857f;
     --ds-color-accent-border-strong: #9eaaa7;
     --ds-color-accent-text-subtle: #9eaaa7;
+    --ds-color-accent-icon-subtle: #9eaaa7;
     --ds-color-accent-text-default: #eaedec;
     --ds-color-accent-base-default: #97aaa4;
     --ds-color-accent-base-hover: #7f968f;
@@ -573,6 +588,7 @@ design-tokens: v1.12.1
     --ds-color-neutral-border-default: #7f8281;
     --ds-color-neutral-border-strong: #a6a8a7;
     --ds-color-neutral-text-subtle: #a6a8a7;
+    --ds-color-neutral-icon-subtle: #a6a8a7;
     --ds-color-neutral-text-default: #ececec;
     --ds-color-neutral-base-default: #a9acab;
     --ds-color-neutral-base-hover: #949796;
@@ -589,6 +605,7 @@ design-tokens: v1.12.1
     --ds-color-support1-border-default: #498e73;
     --ds-color-support1-border-strong: #76b49c;
     --ds-color-support1-text-subtle: #76b49c;
+    --ds-color-support1-icon-subtle: #76b49c;
     --ds-color-support1-text-default: #e2efea;
     --ds-color-support1-base-default: #10684e;
     --ds-color-support1-base-hover: #0d523e;
@@ -605,6 +622,7 @@ design-tokens: v1.12.1
     --ds-color-info-border-default: #5585b4;
     --ds-color-info-border-strong: #8aabcb;
     --ds-color-info-text-subtle: #8aabcb;
+    --ds-color-info-icon-subtle: #8aabcb;
     --ds-color-info-text-default: #e6edf4;
     --ds-color-info-base-default: #2d85c9;
     --ds-color-info-base-hover: #519ad2;
@@ -621,6 +639,7 @@ design-tokens: v1.12.1
     --ds-color-success-border-default: #528f52;
     --ds-color-success-border-strong: #89b289;
     --ds-color-success-text-subtle: #89b289;
+    --ds-color-success-icon-subtle: #89b289;
     --ds-color-success-text-default: #e6efe6;
     --ds-color-success-base-default: #138d24;
     --ds-color-success-base-hover: #3ca14b;
@@ -637,6 +656,7 @@ design-tokens: v1.12.1
     --ds-color-warning-border-default: #a37a46;
     --ds-color-warning-border-strong: #d39e5b;
     --ds-color-warning-text-subtle: #d39e5b;
+    --ds-color-warning-icon-subtle: #d39e5b;
     --ds-color-warning-text-default: #f7ebdb;
     --ds-color-warning-base-default: #60400b;
     --ds-color-warning-base-hover: #7a510e;
@@ -653,6 +673,7 @@ design-tokens: v1.12.1
     --ds-color-danger-border-default: #bc6b64;
     --ds-color-danger-border-strong: #d19a96;
     --ds-color-danger-text-subtle: #d19a96;
+    --ds-color-danger-icon-subtle: #d19a96;
     --ds-color-danger-text-default: #f5eae9;
     --ds-color-danger-base-default: #d76e6e;
     --ds-color-danger-base-hover: #df8b8b;
@@ -678,6 +699,7 @@ design-tokens: v1.12.1
       --ds-color-accent-border-default: #74857f;
       --ds-color-accent-border-strong: #9eaaa7;
       --ds-color-accent-text-subtle: #9eaaa7;
+      --ds-color-accent-icon-subtle: #9eaaa7;
       --ds-color-accent-text-default: #eaedec;
       --ds-color-accent-base-default: #97aaa4;
       --ds-color-accent-base-hover: #7f968f;
@@ -694,6 +716,7 @@ design-tokens: v1.12.1
       --ds-color-neutral-border-default: #7f8281;
       --ds-color-neutral-border-strong: #a6a8a7;
       --ds-color-neutral-text-subtle: #a6a8a7;
+      --ds-color-neutral-icon-subtle: #a6a8a7;
       --ds-color-neutral-text-default: #ececec;
       --ds-color-neutral-base-default: #a9acab;
       --ds-color-neutral-base-hover: #949796;
@@ -710,6 +733,7 @@ design-tokens: v1.12.1
       --ds-color-support1-border-default: #498e73;
       --ds-color-support1-border-strong: #76b49c;
       --ds-color-support1-text-subtle: #76b49c;
+      --ds-color-support1-icon-subtle: #76b49c;
       --ds-color-support1-text-default: #e2efea;
       --ds-color-support1-base-default: #10684e;
       --ds-color-support1-base-hover: #0d523e;
@@ -726,6 +750,7 @@ design-tokens: v1.12.1
       --ds-color-info-border-default: #5585b4;
       --ds-color-info-border-strong: #8aabcb;
       --ds-color-info-text-subtle: #8aabcb;
+      --ds-color-info-icon-subtle: #8aabcb;
       --ds-color-info-text-default: #e6edf4;
       --ds-color-info-base-default: #2d85c9;
       --ds-color-info-base-hover: #519ad2;
@@ -742,6 +767,7 @@ design-tokens: v1.12.1
       --ds-color-success-border-default: #528f52;
       --ds-color-success-border-strong: #89b289;
       --ds-color-success-text-subtle: #89b289;
+      --ds-color-success-icon-subtle: #89b289;
       --ds-color-success-text-default: #e6efe6;
       --ds-color-success-base-default: #138d24;
       --ds-color-success-base-hover: #3ca14b;
@@ -758,6 +784,7 @@ design-tokens: v1.12.1
       --ds-color-warning-border-default: #a37a46;
       --ds-color-warning-border-strong: #d39e5b;
       --ds-color-warning-text-subtle: #d39e5b;
+      --ds-color-warning-icon-subtle: #d39e5b;
       --ds-color-warning-text-default: #f7ebdb;
       --ds-color-warning-base-default: #60400b;
       --ds-color-warning-base-hover: #7a510e;
@@ -774,6 +801,7 @@ design-tokens: v1.12.1
       --ds-color-danger-border-default: #bc6b64;
       --ds-color-danger-border-strong: #d19a96;
       --ds-color-danger-text-subtle: #d19a96;
+      --ds-color-danger-icon-subtle: #d19a96;
       --ds-color-danger-text-default: #f5eae9;
       --ds-color-danger-base-default: #d76e6e;
       --ds-color-danger-base-hover: #df8b8b;
@@ -890,6 +918,7 @@ design-tokens: v1.12.1
     --ds-color-border-default: var(--ds-color-accent-border-default);
     --ds-color-border-strong: var(--ds-color-accent-border-strong);
     --ds-color-text-subtle: var(--ds-color-accent-text-subtle);
+    --ds-color-icon-subtle: var(--ds-color-accent-icon-subtle);
     --ds-color-text-default: var(--ds-color-accent-text-default);
     --ds-color-base-default: var(--ds-color-accent-base-default);
     --ds-color-base-hover: var(--ds-color-accent-base-hover);
@@ -916,6 +945,7 @@ design-tokens: v1.12.1
     --ds-color-border-default: var(--ds-color-danger-border-default);
     --ds-color-border-strong: var(--ds-color-danger-border-strong);
     --ds-color-text-subtle: var(--ds-color-danger-text-subtle);
+    --ds-color-icon-subtle: var(--ds-color-danger-icon-subtle);
     --ds-color-text-default: var(--ds-color-danger-text-default);
     --ds-color-base-default: var(--ds-color-danger-base-default);
     --ds-color-base-hover: var(--ds-color-danger-base-hover);
@@ -942,6 +972,7 @@ design-tokens: v1.12.1
     --ds-color-border-default: var(--ds-color-info-border-default);
     --ds-color-border-strong: var(--ds-color-info-border-strong);
     --ds-color-text-subtle: var(--ds-color-info-text-subtle);
+    --ds-color-icon-subtle: var(--ds-color-info-icon-subtle);
     --ds-color-text-default: var(--ds-color-info-text-default);
     --ds-color-base-default: var(--ds-color-info-base-default);
     --ds-color-base-hover: var(--ds-color-info-base-hover);
@@ -966,6 +997,7 @@ design-tokens: v1.12.1
     --ds-color-border-default: var(--ds-color-neutral-border-default);
     --ds-color-border-strong: var(--ds-color-neutral-border-strong);
     --ds-color-text-subtle: var(--ds-color-neutral-text-subtle);
+    --ds-color-icon-subtle: var(--ds-color-neutral-icon-subtle);
     --ds-color-text-default: var(--ds-color-neutral-text-default);
     --ds-color-base-default: var(--ds-color-neutral-base-default);
     --ds-color-base-hover: var(--ds-color-neutral-base-hover);
@@ -992,6 +1024,7 @@ design-tokens: v1.12.1
     --ds-color-border-default: var(--ds-color-success-border-default);
     --ds-color-border-strong: var(--ds-color-success-border-strong);
     --ds-color-text-subtle: var(--ds-color-success-text-subtle);
+    --ds-color-icon-subtle: var(--ds-color-success-icon-subtle);
     --ds-color-text-default: var(--ds-color-success-text-default);
     --ds-color-base-default: var(--ds-color-success-base-default);
     --ds-color-base-hover: var(--ds-color-success-base-hover);
@@ -1018,6 +1051,7 @@ design-tokens: v1.12.1
     --ds-color-border-default: var(--ds-color-support1-border-default);
     --ds-color-border-strong: var(--ds-color-support1-border-strong);
     --ds-color-text-subtle: var(--ds-color-support1-text-subtle);
+    --ds-color-icon-subtle: var(--ds-color-support1-icon-subtle);
     --ds-color-text-default: var(--ds-color-support1-text-default);
     --ds-color-base-default: var(--ds-color-support1-base-default);
     --ds-color-base-hover: var(--ds-color-support1-base-hover);
@@ -1044,6 +1078,7 @@ design-tokens: v1.12.1
     --ds-color-border-default: var(--ds-color-warning-border-default);
     --ds-color-border-strong: var(--ds-color-warning-border-strong);
     --ds-color-text-subtle: var(--ds-color-warning-text-subtle);
+    --ds-color-icon-subtle: var(--ds-color-warning-icon-subtle);
     --ds-color-text-default: var(--ds-color-warning-text-default);
     --ds-color-base-default: var(--ds-color-warning-base-default);
     --ds-color-base-hover: var(--ds-color-warning-base-hover);

--- a/packages/themes/src/themes/ledsagerbevis.css
+++ b/packages/themes/src/themes/ledsagerbevis.css
@@ -1,7 +1,6 @@
 @charset "UTF-8";
 /*
 build: v1.12.1
-design-tokens: v1.12.1
 */
 
 @layer ds.theme.size-mode {
@@ -129,6 +128,7 @@ design-tokens: v1.12.1
     --ds-color-accent-border-default: #627f76;
     --ds-color-accent-border-strong: #416459;
     --ds-color-accent-text-subtle: #416459;
+    --ds-color-accent-icon-subtle: #416459;
     --ds-color-accent-text-default: #193029;
     --ds-color-accent-base-default: #2b5246;
     --ds-color-accent-base-hover: #213f35;
@@ -145,6 +145,7 @@ design-tokens: v1.12.1
     --ds-color-neutral-border-default: #767978;
     --ds-color-neutral-border-strong: #5a5e5d;
     --ds-color-neutral-text-subtle: #5a5e5d;
+    --ds-color-neutral-icon-subtle: #5a5e5d;
     --ds-color-neutral-text-default: #272d2b;
     --ds-color-neutral-base-default: #1e2422;
     --ds-color-neutral-base-hover: #303533;
@@ -161,6 +162,7 @@ design-tokens: v1.12.1
     --ds-color-support1-border-default: #158967;
     --ds-color-support1-border-strong: #106a50;
     --ds-color-support1-text-subtle: #106a50;
+    --ds-color-support1-icon-subtle: #106a50;
     --ds-color-support1-text-default: #083225;
     --ds-color-support1-base-default: #1aa87e;
     --ds-color-support1-base-hover: #4dbb9b;
@@ -177,6 +179,7 @@ design-tokens: v1.12.1
     --ds-color-info-border-default: #1f7dc5;
     --ds-color-info-border-strong: #0860a3;
     --ds-color-info-text-subtle: #0860a3;
+    --ds-color-info-icon-subtle: #0860a3;
     --ds-color-info-text-default: #042d4d;
     --ds-color-info-base-default: #0a71c0;
     --ds-color-info-base-hover: #085d9f;
@@ -193,6 +196,7 @@ design-tokens: v1.12.1
     --ds-color-success-border-default: #108c22;
     --ds-color-success-border-strong: #056d13;
     --ds-color-success-text-subtle: #056d13;
+    --ds-color-success-icon-subtle: #056d13;
     --ds-color-success-text-default: #023409;
     --ds-color-success-base-default: #068718;
     --ds-color-success-base-hover: #057014;
@@ -209,6 +213,7 @@ design-tokens: v1.12.1
     --ds-color-warning-border-default: #a56d13;
     --ds-color-warning-border-strong: #80540f;
     --ds-color-warning-text-subtle: #80540f;
+    --ds-color-warning-icon-subtle: #80540f;
     --ds-color-warning-text-default: #3c2807;
     --ds-color-warning-base-default: #ea9b1b;
     --ds-color-warning-base-hover: #cd8818;
@@ -225,6 +230,7 @@ design-tokens: v1.12.1
     --ds-color-danger-border-default: #ce4d4d;
     --ds-color-danger-border-strong: #b81a1a;
     --ds-color-danger-text-subtle: #b81a1a;
+    --ds-color-danger-icon-subtle: #b81a1a;
     --ds-color-danger-text-default: #590d0d;
     --ds-color-danger-base-default: #c01b1b;
     --ds-color-danger-base-hover: #9b1616;
@@ -250,6 +256,7 @@ design-tokens: v1.12.1
       --ds-color-accent-border-default: #627f76;
       --ds-color-accent-border-strong: #416459;
       --ds-color-accent-text-subtle: #416459;
+      --ds-color-accent-icon-subtle: #416459;
       --ds-color-accent-text-default: #193029;
       --ds-color-accent-base-default: #2b5246;
       --ds-color-accent-base-hover: #213f35;
@@ -266,6 +273,7 @@ design-tokens: v1.12.1
       --ds-color-neutral-border-default: #767978;
       --ds-color-neutral-border-strong: #5a5e5d;
       --ds-color-neutral-text-subtle: #5a5e5d;
+      --ds-color-neutral-icon-subtle: #5a5e5d;
       --ds-color-neutral-text-default: #272d2b;
       --ds-color-neutral-base-default: #1e2422;
       --ds-color-neutral-base-hover: #303533;
@@ -282,6 +290,7 @@ design-tokens: v1.12.1
       --ds-color-support1-border-default: #158967;
       --ds-color-support1-border-strong: #106a50;
       --ds-color-support1-text-subtle: #106a50;
+      --ds-color-support1-icon-subtle: #106a50;
       --ds-color-support1-text-default: #083225;
       --ds-color-support1-base-default: #1aa87e;
       --ds-color-support1-base-hover: #4dbb9b;
@@ -298,6 +307,7 @@ design-tokens: v1.12.1
       --ds-color-info-border-default: #1f7dc5;
       --ds-color-info-border-strong: #0860a3;
       --ds-color-info-text-subtle: #0860a3;
+      --ds-color-info-icon-subtle: #0860a3;
       --ds-color-info-text-default: #042d4d;
       --ds-color-info-base-default: #0a71c0;
       --ds-color-info-base-hover: #085d9f;
@@ -314,6 +324,7 @@ design-tokens: v1.12.1
       --ds-color-success-border-default: #108c22;
       --ds-color-success-border-strong: #056d13;
       --ds-color-success-text-subtle: #056d13;
+      --ds-color-success-icon-subtle: #056d13;
       --ds-color-success-text-default: #023409;
       --ds-color-success-base-default: #068718;
       --ds-color-success-base-hover: #057014;
@@ -330,6 +341,7 @@ design-tokens: v1.12.1
       --ds-color-warning-border-default: #a56d13;
       --ds-color-warning-border-strong: #80540f;
       --ds-color-warning-text-subtle: #80540f;
+      --ds-color-warning-icon-subtle: #80540f;
       --ds-color-warning-text-default: #3c2807;
       --ds-color-warning-base-default: #ea9b1b;
       --ds-color-warning-base-hover: #cd8818;
@@ -346,6 +358,7 @@ design-tokens: v1.12.1
       --ds-color-danger-border-default: #ce4d4d;
       --ds-color-danger-border-strong: #b81a1a;
       --ds-color-danger-text-subtle: #b81a1a;
+      --ds-color-danger-icon-subtle: #b81a1a;
       --ds-color-danger-text-default: #590d0d;
       --ds-color-danger-base-default: #c01b1b;
       --ds-color-danger-base-hover: #9b1616;
@@ -557,6 +570,7 @@ design-tokens: v1.12.1
     --ds-color-accent-border-default: #74857f;
     --ds-color-accent-border-strong: #9eaaa7;
     --ds-color-accent-text-subtle: #9eaaa7;
+    --ds-color-accent-icon-subtle: #9eaaa7;
     --ds-color-accent-text-default: #eaedec;
     --ds-color-accent-base-default: #97aaa4;
     --ds-color-accent-base-hover: #7f968f;
@@ -573,6 +587,7 @@ design-tokens: v1.12.1
     --ds-color-neutral-border-default: #7f8281;
     --ds-color-neutral-border-strong: #a6a8a7;
     --ds-color-neutral-text-subtle: #a6a8a7;
+    --ds-color-neutral-icon-subtle: #a6a8a7;
     --ds-color-neutral-text-default: #ececec;
     --ds-color-neutral-base-default: #a9acab;
     --ds-color-neutral-base-hover: #949796;
@@ -589,6 +604,7 @@ design-tokens: v1.12.1
     --ds-color-support1-border-default: #498e73;
     --ds-color-support1-border-strong: #76b49c;
     --ds-color-support1-text-subtle: #76b49c;
+    --ds-color-support1-icon-subtle: #76b49c;
     --ds-color-support1-text-default: #e2efea;
     --ds-color-support1-base-default: #10684e;
     --ds-color-support1-base-hover: #0d523e;
@@ -605,6 +621,7 @@ design-tokens: v1.12.1
     --ds-color-info-border-default: #5585b4;
     --ds-color-info-border-strong: #8aabcb;
     --ds-color-info-text-subtle: #8aabcb;
+    --ds-color-info-icon-subtle: #8aabcb;
     --ds-color-info-text-default: #e6edf4;
     --ds-color-info-base-default: #2d85c9;
     --ds-color-info-base-hover: #519ad2;
@@ -621,6 +638,7 @@ design-tokens: v1.12.1
     --ds-color-success-border-default: #528f52;
     --ds-color-success-border-strong: #89b289;
     --ds-color-success-text-subtle: #89b289;
+    --ds-color-success-icon-subtle: #89b289;
     --ds-color-success-text-default: #e6efe6;
     --ds-color-success-base-default: #138d24;
     --ds-color-success-base-hover: #3ca14b;
@@ -637,6 +655,7 @@ design-tokens: v1.12.1
     --ds-color-warning-border-default: #a37a46;
     --ds-color-warning-border-strong: #d39e5b;
     --ds-color-warning-text-subtle: #d39e5b;
+    --ds-color-warning-icon-subtle: #d39e5b;
     --ds-color-warning-text-default: #f7ebdb;
     --ds-color-warning-base-default: #60400b;
     --ds-color-warning-base-hover: #7a510e;
@@ -653,6 +672,7 @@ design-tokens: v1.12.1
     --ds-color-danger-border-default: #bc6b64;
     --ds-color-danger-border-strong: #d19a96;
     --ds-color-danger-text-subtle: #d19a96;
+    --ds-color-danger-icon-subtle: #d19a96;
     --ds-color-danger-text-default: #f5eae9;
     --ds-color-danger-base-default: #d76e6e;
     --ds-color-danger-base-hover: #df8b8b;
@@ -678,6 +698,7 @@ design-tokens: v1.12.1
       --ds-color-accent-border-default: #74857f;
       --ds-color-accent-border-strong: #9eaaa7;
       --ds-color-accent-text-subtle: #9eaaa7;
+      --ds-color-accent-icon-subtle: #9eaaa7;
       --ds-color-accent-text-default: #eaedec;
       --ds-color-accent-base-default: #97aaa4;
       --ds-color-accent-base-hover: #7f968f;
@@ -694,6 +715,7 @@ design-tokens: v1.12.1
       --ds-color-neutral-border-default: #7f8281;
       --ds-color-neutral-border-strong: #a6a8a7;
       --ds-color-neutral-text-subtle: #a6a8a7;
+      --ds-color-neutral-icon-subtle: #a6a8a7;
       --ds-color-neutral-text-default: #ececec;
       --ds-color-neutral-base-default: #a9acab;
       --ds-color-neutral-base-hover: #949796;
@@ -710,6 +732,7 @@ design-tokens: v1.12.1
       --ds-color-support1-border-default: #498e73;
       --ds-color-support1-border-strong: #76b49c;
       --ds-color-support1-text-subtle: #76b49c;
+      --ds-color-support1-icon-subtle: #76b49c;
       --ds-color-support1-text-default: #e2efea;
       --ds-color-support1-base-default: #10684e;
       --ds-color-support1-base-hover: #0d523e;
@@ -726,6 +749,7 @@ design-tokens: v1.12.1
       --ds-color-info-border-default: #5585b4;
       --ds-color-info-border-strong: #8aabcb;
       --ds-color-info-text-subtle: #8aabcb;
+      --ds-color-info-icon-subtle: #8aabcb;
       --ds-color-info-text-default: #e6edf4;
       --ds-color-info-base-default: #2d85c9;
       --ds-color-info-base-hover: #519ad2;
@@ -742,6 +766,7 @@ design-tokens: v1.12.1
       --ds-color-success-border-default: #528f52;
       --ds-color-success-border-strong: #89b289;
       --ds-color-success-text-subtle: #89b289;
+      --ds-color-success-icon-subtle: #89b289;
       --ds-color-success-text-default: #e6efe6;
       --ds-color-success-base-default: #138d24;
       --ds-color-success-base-hover: #3ca14b;
@@ -758,6 +783,7 @@ design-tokens: v1.12.1
       --ds-color-warning-border-default: #a37a46;
       --ds-color-warning-border-strong: #d39e5b;
       --ds-color-warning-text-subtle: #d39e5b;
+      --ds-color-warning-icon-subtle: #d39e5b;
       --ds-color-warning-text-default: #f7ebdb;
       --ds-color-warning-base-default: #60400b;
       --ds-color-warning-base-hover: #7a510e;
@@ -774,6 +800,7 @@ design-tokens: v1.12.1
       --ds-color-danger-border-default: #bc6b64;
       --ds-color-danger-border-strong: #d19a96;
       --ds-color-danger-text-subtle: #d19a96;
+      --ds-color-danger-icon-subtle: #d19a96;
       --ds-color-danger-text-default: #f5eae9;
       --ds-color-danger-base-default: #d76e6e;
       --ds-color-danger-base-hover: #df8b8b;
@@ -890,6 +917,7 @@ design-tokens: v1.12.1
     --ds-color-border-default: var(--ds-color-accent-border-default);
     --ds-color-border-strong: var(--ds-color-accent-border-strong);
     --ds-color-text-subtle: var(--ds-color-accent-text-subtle);
+    --ds-color-icon-subtle: var(--ds-color-accent-text-subtle);
     --ds-color-text-default: var(--ds-color-accent-text-default);
     --ds-color-base-default: var(--ds-color-accent-base-default);
     --ds-color-base-hover: var(--ds-color-accent-base-hover);
@@ -916,6 +944,7 @@ design-tokens: v1.12.1
     --ds-color-border-default: var(--ds-color-danger-border-default);
     --ds-color-border-strong: var(--ds-color-danger-border-strong);
     --ds-color-text-subtle: var(--ds-color-danger-text-subtle);
+    --ds-color-icon-subtle: var(--ds-color-danger-icon-subtle);
     --ds-color-text-default: var(--ds-color-danger-text-default);
     --ds-color-base-default: var(--ds-color-danger-base-default);
     --ds-color-base-hover: var(--ds-color-danger-base-hover);
@@ -942,6 +971,7 @@ design-tokens: v1.12.1
     --ds-color-border-default: var(--ds-color-info-border-default);
     --ds-color-border-strong: var(--ds-color-info-border-strong);
     --ds-color-text-subtle: var(--ds-color-info-text-subtle);
+    --ds-color-icon-subtle: var(--ds-color-info-icon-subtle);
     --ds-color-text-default: var(--ds-color-info-text-default);
     --ds-color-base-default: var(--ds-color-info-base-default);
     --ds-color-base-hover: var(--ds-color-info-base-hover);
@@ -966,6 +996,7 @@ design-tokens: v1.12.1
     --ds-color-border-default: var(--ds-color-neutral-border-default);
     --ds-color-border-strong: var(--ds-color-neutral-border-strong);
     --ds-color-text-subtle: var(--ds-color-neutral-text-subtle);
+    --ds-color-icon-subtle: var(--ds-color-neutral-icon-subtle);
     --ds-color-text-default: var(--ds-color-neutral-text-default);
     --ds-color-base-default: var(--ds-color-neutral-base-default);
     --ds-color-base-hover: var(--ds-color-neutral-base-hover);
@@ -992,6 +1023,7 @@ design-tokens: v1.12.1
     --ds-color-border-default: var(--ds-color-success-border-default);
     --ds-color-border-strong: var(--ds-color-success-border-strong);
     --ds-color-text-subtle: var(--ds-color-success-text-subtle);
+    --ds-color-icon-subtle: var(--ds-color-success-icon-subtle);
     --ds-color-text-default: var(--ds-color-success-text-default);
     --ds-color-base-default: var(--ds-color-success-base-default);
     --ds-color-base-hover: var(--ds-color-success-base-hover);
@@ -1018,6 +1050,7 @@ design-tokens: v1.12.1
     --ds-color-border-default: var(--ds-color-support1-border-default);
     --ds-color-border-strong: var(--ds-color-support1-border-strong);
     --ds-color-text-subtle: var(--ds-color-support1-text-subtle);
+    --ds-color-icon-subtle: var(--ds-color-support1-text-subtle);
     --ds-color-text-default: var(--ds-color-support1-text-default);
     --ds-color-base-default: var(--ds-color-support1-base-default);
     --ds-color-base-hover: var(--ds-color-support1-base-hover);
@@ -1044,6 +1077,7 @@ design-tokens: v1.12.1
     --ds-color-border-default: var(--ds-color-warning-border-default);
     --ds-color-border-strong: var(--ds-color-warning-border-strong);
     --ds-color-text-subtle: var(--ds-color-warning-text-subtle);
+    --ds-color-icon-subtle: var(--ds-color-warning-icon-subtle);
     --ds-color-text-default: var(--ds-color-warning-text-default);
     --ds-color-base-default: var(--ds-color-warning-base-default);
     --ds-color-base-hover: var(--ds-color-warning-base-hover);

--- a/packages/themes/src/themes/ledsagerbevis.css
+++ b/packages/themes/src/themes/ledsagerbevis.css
@@ -917,7 +917,7 @@ build: v1.12.1
     --ds-color-border-default: var(--ds-color-accent-border-default);
     --ds-color-border-strong: var(--ds-color-accent-border-strong);
     --ds-color-text-subtle: var(--ds-color-accent-text-subtle);
-    --ds-color-icon-subtle: var(--ds-color-accent-text-subtle);
+    --ds-color-icon-subtle: var(--ds-color-accent-icon-subtle);
     --ds-color-text-default: var(--ds-color-accent-text-default);
     --ds-color-base-default: var(--ds-color-accent-base-default);
     --ds-color-base-hover: var(--ds-color-accent-base-hover);
@@ -1050,7 +1050,7 @@ build: v1.12.1
     --ds-color-border-default: var(--ds-color-support1-border-default);
     --ds-color-border-strong: var(--ds-color-support1-border-strong);
     --ds-color-text-subtle: var(--ds-color-support1-text-subtle);
-    --ds-color-icon-subtle: var(--ds-color-support1-text-subtle);
+    --ds-color-icon-subtle: var(--ds-color-support1-icon-subtle);
     --ds-color-text-default: var(--ds-color-support1-text-default);
     --ds-color-base-default: var(--ds-color-support1-base-default);
     --ds-color-base-hover: var(--ds-color-support1-base-hover);

--- a/packages/themes/src/themes/ledsagerbevis.css
+++ b/packages/themes/src/themes/ledsagerbevis.css
@@ -1,6 +1,7 @@
 @charset "UTF-8";
 /*
 build: v1.12.1
+design-tokens: v1.12.1
 */
 
 @layer ds.theme.size-mode {
@@ -128,7 +129,6 @@ build: v1.12.1
     --ds-color-accent-border-default: #627f76;
     --ds-color-accent-border-strong: #416459;
     --ds-color-accent-text-subtle: #416459;
-    --ds-color-accent-icon-subtle: #416459;
     --ds-color-accent-text-default: #193029;
     --ds-color-accent-base-default: #2b5246;
     --ds-color-accent-base-hover: #213f35;
@@ -145,7 +145,6 @@ build: v1.12.1
     --ds-color-neutral-border-default: #767978;
     --ds-color-neutral-border-strong: #5a5e5d;
     --ds-color-neutral-text-subtle: #5a5e5d;
-    --ds-color-neutral-icon-subtle: #5a5e5d;
     --ds-color-neutral-text-default: #272d2b;
     --ds-color-neutral-base-default: #1e2422;
     --ds-color-neutral-base-hover: #303533;
@@ -162,7 +161,6 @@ build: v1.12.1
     --ds-color-support1-border-default: #158967;
     --ds-color-support1-border-strong: #106a50;
     --ds-color-support1-text-subtle: #106a50;
-    --ds-color-support1-icon-subtle: #106a50;
     --ds-color-support1-text-default: #083225;
     --ds-color-support1-base-default: #1aa87e;
     --ds-color-support1-base-hover: #4dbb9b;
@@ -179,7 +177,6 @@ build: v1.12.1
     --ds-color-info-border-default: #1f7dc5;
     --ds-color-info-border-strong: #0860a3;
     --ds-color-info-text-subtle: #0860a3;
-    --ds-color-info-icon-subtle: #0860a3;
     --ds-color-info-text-default: #042d4d;
     --ds-color-info-base-default: #0a71c0;
     --ds-color-info-base-hover: #085d9f;
@@ -196,7 +193,6 @@ build: v1.12.1
     --ds-color-success-border-default: #108c22;
     --ds-color-success-border-strong: #056d13;
     --ds-color-success-text-subtle: #056d13;
-    --ds-color-success-icon-subtle: #056d13;
     --ds-color-success-text-default: #023409;
     --ds-color-success-base-default: #068718;
     --ds-color-success-base-hover: #057014;
@@ -213,7 +209,6 @@ build: v1.12.1
     --ds-color-warning-border-default: #a56d13;
     --ds-color-warning-border-strong: #80540f;
     --ds-color-warning-text-subtle: #80540f;
-    --ds-color-warning-icon-subtle: #80540f;
     --ds-color-warning-text-default: #3c2807;
     --ds-color-warning-base-default: #ea9b1b;
     --ds-color-warning-base-hover: #cd8818;
@@ -230,7 +225,6 @@ build: v1.12.1
     --ds-color-danger-border-default: #ce4d4d;
     --ds-color-danger-border-strong: #b81a1a;
     --ds-color-danger-text-subtle: #b81a1a;
-    --ds-color-danger-icon-subtle: #b81a1a;
     --ds-color-danger-text-default: #590d0d;
     --ds-color-danger-base-default: #c01b1b;
     --ds-color-danger-base-hover: #9b1616;
@@ -256,7 +250,6 @@ build: v1.12.1
       --ds-color-accent-border-default: #627f76;
       --ds-color-accent-border-strong: #416459;
       --ds-color-accent-text-subtle: #416459;
-      --ds-color-accent-icon-subtle: #416459;
       --ds-color-accent-text-default: #193029;
       --ds-color-accent-base-default: #2b5246;
       --ds-color-accent-base-hover: #213f35;
@@ -273,7 +266,6 @@ build: v1.12.1
       --ds-color-neutral-border-default: #767978;
       --ds-color-neutral-border-strong: #5a5e5d;
       --ds-color-neutral-text-subtle: #5a5e5d;
-      --ds-color-neutral-icon-subtle: #5a5e5d;
       --ds-color-neutral-text-default: #272d2b;
       --ds-color-neutral-base-default: #1e2422;
       --ds-color-neutral-base-hover: #303533;
@@ -290,7 +282,6 @@ build: v1.12.1
       --ds-color-support1-border-default: #158967;
       --ds-color-support1-border-strong: #106a50;
       --ds-color-support1-text-subtle: #106a50;
-      --ds-color-support1-icon-subtle: #106a50;
       --ds-color-support1-text-default: #083225;
       --ds-color-support1-base-default: #1aa87e;
       --ds-color-support1-base-hover: #4dbb9b;
@@ -307,7 +298,6 @@ build: v1.12.1
       --ds-color-info-border-default: #1f7dc5;
       --ds-color-info-border-strong: #0860a3;
       --ds-color-info-text-subtle: #0860a3;
-      --ds-color-info-icon-subtle: #0860a3;
       --ds-color-info-text-default: #042d4d;
       --ds-color-info-base-default: #0a71c0;
       --ds-color-info-base-hover: #085d9f;
@@ -324,7 +314,6 @@ build: v1.12.1
       --ds-color-success-border-default: #108c22;
       --ds-color-success-border-strong: #056d13;
       --ds-color-success-text-subtle: #056d13;
-      --ds-color-success-icon-subtle: #056d13;
       --ds-color-success-text-default: #023409;
       --ds-color-success-base-default: #068718;
       --ds-color-success-base-hover: #057014;
@@ -341,7 +330,6 @@ build: v1.12.1
       --ds-color-warning-border-default: #a56d13;
       --ds-color-warning-border-strong: #80540f;
       --ds-color-warning-text-subtle: #80540f;
-      --ds-color-warning-icon-subtle: #80540f;
       --ds-color-warning-text-default: #3c2807;
       --ds-color-warning-base-default: #ea9b1b;
       --ds-color-warning-base-hover: #cd8818;
@@ -358,7 +346,6 @@ build: v1.12.1
       --ds-color-danger-border-default: #ce4d4d;
       --ds-color-danger-border-strong: #b81a1a;
       --ds-color-danger-text-subtle: #b81a1a;
-      --ds-color-danger-icon-subtle: #b81a1a;
       --ds-color-danger-text-default: #590d0d;
       --ds-color-danger-base-default: #c01b1b;
       --ds-color-danger-base-hover: #9b1616;
@@ -570,7 +557,6 @@ build: v1.12.1
     --ds-color-accent-border-default: #74857f;
     --ds-color-accent-border-strong: #9eaaa7;
     --ds-color-accent-text-subtle: #9eaaa7;
-    --ds-color-accent-icon-subtle: #9eaaa7;
     --ds-color-accent-text-default: #eaedec;
     --ds-color-accent-base-default: #97aaa4;
     --ds-color-accent-base-hover: #7f968f;
@@ -587,7 +573,6 @@ build: v1.12.1
     --ds-color-neutral-border-default: #7f8281;
     --ds-color-neutral-border-strong: #a6a8a7;
     --ds-color-neutral-text-subtle: #a6a8a7;
-    --ds-color-neutral-icon-subtle: #a6a8a7;
     --ds-color-neutral-text-default: #ececec;
     --ds-color-neutral-base-default: #a9acab;
     --ds-color-neutral-base-hover: #949796;
@@ -604,7 +589,6 @@ build: v1.12.1
     --ds-color-support1-border-default: #498e73;
     --ds-color-support1-border-strong: #76b49c;
     --ds-color-support1-text-subtle: #76b49c;
-    --ds-color-support1-icon-subtle: #76b49c;
     --ds-color-support1-text-default: #e2efea;
     --ds-color-support1-base-default: #10684e;
     --ds-color-support1-base-hover: #0d523e;
@@ -621,7 +605,6 @@ build: v1.12.1
     --ds-color-info-border-default: #5585b4;
     --ds-color-info-border-strong: #8aabcb;
     --ds-color-info-text-subtle: #8aabcb;
-    --ds-color-info-icon-subtle: #8aabcb;
     --ds-color-info-text-default: #e6edf4;
     --ds-color-info-base-default: #2d85c9;
     --ds-color-info-base-hover: #519ad2;
@@ -638,7 +621,6 @@ build: v1.12.1
     --ds-color-success-border-default: #528f52;
     --ds-color-success-border-strong: #89b289;
     --ds-color-success-text-subtle: #89b289;
-    --ds-color-success-icon-subtle: #89b289;
     --ds-color-success-text-default: #e6efe6;
     --ds-color-success-base-default: #138d24;
     --ds-color-success-base-hover: #3ca14b;
@@ -655,7 +637,6 @@ build: v1.12.1
     --ds-color-warning-border-default: #a37a46;
     --ds-color-warning-border-strong: #d39e5b;
     --ds-color-warning-text-subtle: #d39e5b;
-    --ds-color-warning-icon-subtle: #d39e5b;
     --ds-color-warning-text-default: #f7ebdb;
     --ds-color-warning-base-default: #60400b;
     --ds-color-warning-base-hover: #7a510e;
@@ -672,7 +653,6 @@ build: v1.12.1
     --ds-color-danger-border-default: #bc6b64;
     --ds-color-danger-border-strong: #d19a96;
     --ds-color-danger-text-subtle: #d19a96;
-    --ds-color-danger-icon-subtle: #d19a96;
     --ds-color-danger-text-default: #f5eae9;
     --ds-color-danger-base-default: #d76e6e;
     --ds-color-danger-base-hover: #df8b8b;
@@ -698,7 +678,6 @@ build: v1.12.1
       --ds-color-accent-border-default: #74857f;
       --ds-color-accent-border-strong: #9eaaa7;
       --ds-color-accent-text-subtle: #9eaaa7;
-      --ds-color-accent-icon-subtle: #9eaaa7;
       --ds-color-accent-text-default: #eaedec;
       --ds-color-accent-base-default: #97aaa4;
       --ds-color-accent-base-hover: #7f968f;
@@ -715,7 +694,6 @@ build: v1.12.1
       --ds-color-neutral-border-default: #7f8281;
       --ds-color-neutral-border-strong: #a6a8a7;
       --ds-color-neutral-text-subtle: #a6a8a7;
-      --ds-color-neutral-icon-subtle: #a6a8a7;
       --ds-color-neutral-text-default: #ececec;
       --ds-color-neutral-base-default: #a9acab;
       --ds-color-neutral-base-hover: #949796;
@@ -732,7 +710,6 @@ build: v1.12.1
       --ds-color-support1-border-default: #498e73;
       --ds-color-support1-border-strong: #76b49c;
       --ds-color-support1-text-subtle: #76b49c;
-      --ds-color-support1-icon-subtle: #76b49c;
       --ds-color-support1-text-default: #e2efea;
       --ds-color-support1-base-default: #10684e;
       --ds-color-support1-base-hover: #0d523e;
@@ -749,7 +726,6 @@ build: v1.12.1
       --ds-color-info-border-default: #5585b4;
       --ds-color-info-border-strong: #8aabcb;
       --ds-color-info-text-subtle: #8aabcb;
-      --ds-color-info-icon-subtle: #8aabcb;
       --ds-color-info-text-default: #e6edf4;
       --ds-color-info-base-default: #2d85c9;
       --ds-color-info-base-hover: #519ad2;
@@ -766,7 +742,6 @@ build: v1.12.1
       --ds-color-success-border-default: #528f52;
       --ds-color-success-border-strong: #89b289;
       --ds-color-success-text-subtle: #89b289;
-      --ds-color-success-icon-subtle: #89b289;
       --ds-color-success-text-default: #e6efe6;
       --ds-color-success-base-default: #138d24;
       --ds-color-success-base-hover: #3ca14b;
@@ -783,7 +758,6 @@ build: v1.12.1
       --ds-color-warning-border-default: #a37a46;
       --ds-color-warning-border-strong: #d39e5b;
       --ds-color-warning-text-subtle: #d39e5b;
-      --ds-color-warning-icon-subtle: #d39e5b;
       --ds-color-warning-text-default: #f7ebdb;
       --ds-color-warning-base-default: #60400b;
       --ds-color-warning-base-hover: #7a510e;
@@ -800,7 +774,6 @@ build: v1.12.1
       --ds-color-danger-border-default: #bc6b64;
       --ds-color-danger-border-strong: #d19a96;
       --ds-color-danger-text-subtle: #d19a96;
-      --ds-color-danger-icon-subtle: #d19a96;
       --ds-color-danger-text-default: #f5eae9;
       --ds-color-danger-base-default: #d76e6e;
       --ds-color-danger-base-hover: #df8b8b;
@@ -917,7 +890,6 @@ build: v1.12.1
     --ds-color-border-default: var(--ds-color-accent-border-default);
     --ds-color-border-strong: var(--ds-color-accent-border-strong);
     --ds-color-text-subtle: var(--ds-color-accent-text-subtle);
-    --ds-color-icon-subtle: var(--ds-color-accent-icon-subtle);
     --ds-color-text-default: var(--ds-color-accent-text-default);
     --ds-color-base-default: var(--ds-color-accent-base-default);
     --ds-color-base-hover: var(--ds-color-accent-base-hover);
@@ -944,7 +916,6 @@ build: v1.12.1
     --ds-color-border-default: var(--ds-color-danger-border-default);
     --ds-color-border-strong: var(--ds-color-danger-border-strong);
     --ds-color-text-subtle: var(--ds-color-danger-text-subtle);
-    --ds-color-icon-subtle: var(--ds-color-danger-icon-subtle);
     --ds-color-text-default: var(--ds-color-danger-text-default);
     --ds-color-base-default: var(--ds-color-danger-base-default);
     --ds-color-base-hover: var(--ds-color-danger-base-hover);
@@ -971,7 +942,6 @@ build: v1.12.1
     --ds-color-border-default: var(--ds-color-info-border-default);
     --ds-color-border-strong: var(--ds-color-info-border-strong);
     --ds-color-text-subtle: var(--ds-color-info-text-subtle);
-    --ds-color-icon-subtle: var(--ds-color-info-icon-subtle);
     --ds-color-text-default: var(--ds-color-info-text-default);
     --ds-color-base-default: var(--ds-color-info-base-default);
     --ds-color-base-hover: var(--ds-color-info-base-hover);
@@ -996,7 +966,6 @@ build: v1.12.1
     --ds-color-border-default: var(--ds-color-neutral-border-default);
     --ds-color-border-strong: var(--ds-color-neutral-border-strong);
     --ds-color-text-subtle: var(--ds-color-neutral-text-subtle);
-    --ds-color-icon-subtle: var(--ds-color-neutral-icon-subtle);
     --ds-color-text-default: var(--ds-color-neutral-text-default);
     --ds-color-base-default: var(--ds-color-neutral-base-default);
     --ds-color-base-hover: var(--ds-color-neutral-base-hover);
@@ -1023,7 +992,6 @@ build: v1.12.1
     --ds-color-border-default: var(--ds-color-success-border-default);
     --ds-color-border-strong: var(--ds-color-success-border-strong);
     --ds-color-text-subtle: var(--ds-color-success-text-subtle);
-    --ds-color-icon-subtle: var(--ds-color-success-icon-subtle);
     --ds-color-text-default: var(--ds-color-success-text-default);
     --ds-color-base-default: var(--ds-color-success-base-default);
     --ds-color-base-hover: var(--ds-color-success-base-hover);
@@ -1050,7 +1018,6 @@ build: v1.12.1
     --ds-color-border-default: var(--ds-color-support1-border-default);
     --ds-color-border-strong: var(--ds-color-support1-border-strong);
     --ds-color-text-subtle: var(--ds-color-support1-text-subtle);
-    --ds-color-icon-subtle: var(--ds-color-support1-icon-subtle);
     --ds-color-text-default: var(--ds-color-support1-text-default);
     --ds-color-base-default: var(--ds-color-support1-base-default);
     --ds-color-base-hover: var(--ds-color-support1-base-hover);
@@ -1077,7 +1044,6 @@ build: v1.12.1
     --ds-color-border-default: var(--ds-color-warning-border-default);
     --ds-color-border-strong: var(--ds-color-warning-border-strong);
     --ds-color-text-subtle: var(--ds-color-warning-text-subtle);
-    --ds-color-icon-subtle: var(--ds-color-warning-icon-subtle);
     --ds-color-text-default: var(--ds-color-warning-text-default);
     --ds-color-base-default: var(--ds-color-warning-base-default);
     --ds-color-base-hover: var(--ds-color-warning-base-hover);

--- a/packages/themes/src/themes/ledsagerbevis.tailwind.css
+++ b/packages/themes/src/themes/ledsagerbevis.tailwind.css
@@ -18,6 +18,7 @@
   --color-accent-border-default: var(--ds-color-accent-border-default);
   --color-accent-border-strong: var(--ds-color-accent-border-strong);
   --color-accent-border-subtle: var(--ds-color-accent-border-subtle);
+  --color-accent-icon-subtle: var(--ds-color-accent-icon-subtle);
   --color-accent-surface-active: var(--ds-color-accent-surface-active);
   --color-accent-surface-default: var(--ds-color-accent-surface-default);
   --color-accent-surface-hover: var(--ds-color-accent-surface-hover);
@@ -48,12 +49,14 @@
   --color-danger-border-default: var(--ds-color-danger-border-default);
   --color-danger-border-strong: var(--ds-color-danger-border-strong);
   --color-danger-border-subtle: var(--ds-color-danger-border-subtle);
+  --color-danger-icon-subtle: var(--ds-color-danger-icon-subtle);
   --color-danger-surface-active: var(--ds-color-danger-surface-active);
   --color-danger-surface-default: var(--ds-color-danger-surface-default);
   --color-danger-surface-hover: var(--ds-color-danger-surface-hover);
   --color-danger-surface-tinted: var(--ds-color-danger-surface-tinted);
   --color-danger-text-default: var(--ds-color-danger-text-default);
   --color-danger-text-subtle: var(--ds-color-danger-text-subtle);
+  --color-icon-subtle: var(--ds-color-icon-subtle);
   --color-info-background-default: var(--ds-color-info-background-default);
   --color-info-background-tinted: var(--ds-color-info-background-tinted);
   --color-info-base-active: var(--ds-color-info-base-active);
@@ -66,6 +69,7 @@
   --color-info-border-default: var(--ds-color-info-border-default);
   --color-info-border-strong: var(--ds-color-info-border-strong);
   --color-info-border-subtle: var(--ds-color-info-border-subtle);
+  --color-info-icon-subtle: var(--ds-color-info-icon-subtle);
   --color-info-surface-active: var(--ds-color-info-surface-active);
   --color-info-surface-default: var(--ds-color-info-surface-default);
   --color-info-surface-hover: var(--ds-color-info-surface-hover);
@@ -88,6 +92,7 @@
   --color-neutral-border-default: var(--ds-color-neutral-border-default);
   --color-neutral-border-strong: var(--ds-color-neutral-border-strong);
   --color-neutral-border-subtle: var(--ds-color-neutral-border-subtle);
+  --color-neutral-icon-subtle: var(--ds-color-neutral-icon-subtle);
   --color-neutral-surface-active: var(--ds-color-neutral-surface-active);
   --color-neutral-surface-default: var(--ds-color-neutral-surface-default);
   --color-neutral-surface-hover: var(--ds-color-neutral-surface-hover);
@@ -110,6 +115,7 @@
   --color-success-border-default: var(--ds-color-success-border-default);
   --color-success-border-strong: var(--ds-color-success-border-strong);
   --color-success-border-subtle: var(--ds-color-success-border-subtle);
+  --color-success-icon-subtle: var(--ds-color-success-icon-subtle);
   --color-success-surface-active: var(--ds-color-success-surface-active);
   --color-success-surface-default: var(--ds-color-success-surface-default);
   --color-success-surface-hover: var(--ds-color-success-surface-hover);
@@ -134,6 +140,7 @@
   --color-support1-border-default: var(--ds-color-support1-border-default);
   --color-support1-border-strong: var(--ds-color-support1-border-strong);
   --color-support1-border-subtle: var(--ds-color-support1-border-subtle);
+  --color-support1-icon-subtle: var(--ds-color-support1-icon-subtle);
   --color-support1-surface-active: var(--ds-color-support1-surface-active);
   --color-support1-surface-default: var(--ds-color-support1-surface-default);
   --color-support1-surface-hover: var(--ds-color-support1-surface-hover);
@@ -162,6 +169,7 @@
   --color-warning-border-default: var(--ds-color-warning-border-default);
   --color-warning-border-strong: var(--ds-color-warning-border-strong);
   --color-warning-border-subtle: var(--ds-color-warning-border-subtle);
+  --color-warning-icon-subtle: var(--ds-color-warning-icon-subtle);
   --color-warning-surface-active: var(--ds-color-warning-surface-active);
   --color-warning-surface-default: var(--ds-color-warning-surface-default);
   --color-warning-surface-hover: var(--ds-color-warning-surface-hover);

--- a/packages/themes/src/themes/ledsagerbevis.tailwind.css
+++ b/packages/themes/src/themes/ledsagerbevis.tailwind.css
@@ -18,7 +18,6 @@
   --color-accent-border-default: var(--ds-color-accent-border-default);
   --color-accent-border-strong: var(--ds-color-accent-border-strong);
   --color-accent-border-subtle: var(--ds-color-accent-border-subtle);
-  --color-accent-icon-subtle: var(--ds-color-accent-icon-subtle);
   --color-accent-surface-active: var(--ds-color-accent-surface-active);
   --color-accent-surface-default: var(--ds-color-accent-surface-default);
   --color-accent-surface-hover: var(--ds-color-accent-surface-hover);
@@ -49,14 +48,12 @@
   --color-danger-border-default: var(--ds-color-danger-border-default);
   --color-danger-border-strong: var(--ds-color-danger-border-strong);
   --color-danger-border-subtle: var(--ds-color-danger-border-subtle);
-  --color-danger-icon-subtle: var(--ds-color-danger-icon-subtle);
   --color-danger-surface-active: var(--ds-color-danger-surface-active);
   --color-danger-surface-default: var(--ds-color-danger-surface-default);
   --color-danger-surface-hover: var(--ds-color-danger-surface-hover);
   --color-danger-surface-tinted: var(--ds-color-danger-surface-tinted);
   --color-danger-text-default: var(--ds-color-danger-text-default);
   --color-danger-text-subtle: var(--ds-color-danger-text-subtle);
-  --color-icon-subtle: var(--ds-color-icon-subtle);
   --color-info-background-default: var(--ds-color-info-background-default);
   --color-info-background-tinted: var(--ds-color-info-background-tinted);
   --color-info-base-active: var(--ds-color-info-base-active);
@@ -69,7 +66,6 @@
   --color-info-border-default: var(--ds-color-info-border-default);
   --color-info-border-strong: var(--ds-color-info-border-strong);
   --color-info-border-subtle: var(--ds-color-info-border-subtle);
-  --color-info-icon-subtle: var(--ds-color-info-icon-subtle);
   --color-info-surface-active: var(--ds-color-info-surface-active);
   --color-info-surface-default: var(--ds-color-info-surface-default);
   --color-info-surface-hover: var(--ds-color-info-surface-hover);
@@ -92,7 +88,6 @@
   --color-neutral-border-default: var(--ds-color-neutral-border-default);
   --color-neutral-border-strong: var(--ds-color-neutral-border-strong);
   --color-neutral-border-subtle: var(--ds-color-neutral-border-subtle);
-  --color-neutral-icon-subtle: var(--ds-color-neutral-icon-subtle);
   --color-neutral-surface-active: var(--ds-color-neutral-surface-active);
   --color-neutral-surface-default: var(--ds-color-neutral-surface-default);
   --color-neutral-surface-hover: var(--ds-color-neutral-surface-hover);
@@ -115,7 +110,6 @@
   --color-success-border-default: var(--ds-color-success-border-default);
   --color-success-border-strong: var(--ds-color-success-border-strong);
   --color-success-border-subtle: var(--ds-color-success-border-subtle);
-  --color-success-icon-subtle: var(--ds-color-success-icon-subtle);
   --color-success-surface-active: var(--ds-color-success-surface-active);
   --color-success-surface-default: var(--ds-color-success-surface-default);
   --color-success-surface-hover: var(--ds-color-success-surface-hover);
@@ -140,7 +134,6 @@
   --color-support1-border-default: var(--ds-color-support1-border-default);
   --color-support1-border-strong: var(--ds-color-support1-border-strong);
   --color-support1-border-subtle: var(--ds-color-support1-border-subtle);
-  --color-support1-icon-subtle: var(--ds-color-support1-icon-subtle);
   --color-support1-surface-active: var(--ds-color-support1-surface-active);
   --color-support1-surface-default: var(--ds-color-support1-surface-default);
   --color-support1-surface-hover: var(--ds-color-support1-surface-hover);
@@ -169,7 +162,6 @@
   --color-warning-border-default: var(--ds-color-warning-border-default);
   --color-warning-border-strong: var(--ds-color-warning-border-strong);
   --color-warning-border-subtle: var(--ds-color-warning-border-subtle);
-  --color-warning-icon-subtle: var(--ds-color-warning-icon-subtle);
   --color-warning-surface-active: var(--ds-color-warning-surface-active);
   --color-warning-surface-default: var(--ds-color-warning-surface-default);
   --color-warning-surface-hover: var(--ds-color-warning-surface-hover);
@@ -211,6 +203,7 @@
   --color-border-default: var(--ds-color-border-default);
   --color-border-strong: var(--ds-color-border-strong);
   --color-text-subtle: var(--ds-color-text-subtle);
+  --color-icon-subtle: var(--ds-color-icon-subtle);
   --color-text-default: var(--ds-color-text-default);
   --color-base-default: var(--ds-color-base-default);
   --color-base-hover: var(--ds-color-base-hover);

--- a/packages/themes/src/themes/minkommune.css
+++ b/packages/themes/src/themes/minkommune.css
@@ -1,6 +1,7 @@
 @charset "UTF-8";
 /*
 build: v1.12.1
+design-tokens: v1.12.1
 */
 
 @layer ds.theme.size-mode {
@@ -128,7 +129,6 @@ build: v1.12.1
     --ds-color-accent-border-default: #75778e;
     --ds-color-accent-border-strong: #595b77;
     --ds-color-accent-text-subtle: #595b77;
-    --ds-color-accent-icon-subtle: #595b77;
     --ds-color-accent-text-default: #25284c;
     --ds-color-accent-base-default: #00042e;
     --ds-color-accent-base-hover: #151940;
@@ -145,7 +145,6 @@ build: v1.12.1
     --ds-color-neutral-border-default: #74797e;
     --ds-color-neutral-border-strong: #585e64;
     --ds-color-neutral-text-subtle: #585e64;
-    --ds-color-neutral-icon-subtle: #585e64;
     --ds-color-neutral-text-default: #242c34;
     --ds-color-neutral-base-default: #1d252d;
     --ds-color-neutral-base-hover: #2f363d;
@@ -162,7 +161,6 @@ build: v1.12.1
     --ds-color-support1-border-default: #8060ec;
     --ds-color-support1-border-strong: #6244cb;
     --ds-color-support1-text-subtle: #6244cb;
-    --ds-color-support1-icon-subtle: #6244cb;
     --ds-color-support1-text-default: #2e2060;
     --ds-color-support1-base-default: #714eea;
     --ds-color-support1-base-hover: #5d40c0;
@@ -179,7 +177,6 @@ build: v1.12.1
     --ds-color-info-border-default: #1f7dc5;
     --ds-color-info-border-strong: #0860a3;
     --ds-color-info-text-subtle: #0860a3;
-    --ds-color-info-icon-subtle: #0860a3;
     --ds-color-info-text-default: #042d4d;
     --ds-color-info-base-default: #0a71c0;
     --ds-color-info-base-hover: #085d9f;
@@ -196,7 +193,6 @@ build: v1.12.1
     --ds-color-success-border-default: #108c22;
     --ds-color-success-border-strong: #056d13;
     --ds-color-success-text-subtle: #056d13;
-    --ds-color-success-icon-subtle: #056d13;
     --ds-color-success-text-default: #023409;
     --ds-color-success-base-default: #068718;
     --ds-color-success-base-hover: #057014;
@@ -213,7 +209,6 @@ build: v1.12.1
     --ds-color-warning-border-default: #a56d13;
     --ds-color-warning-border-strong: #80540f;
     --ds-color-warning-text-subtle: #80540f;
-    --ds-color-warning-icon-subtle: #80540f;
     --ds-color-warning-text-default: #3c2807;
     --ds-color-warning-base-default: #ea9b1b;
     --ds-color-warning-base-hover: #cd8818;
@@ -230,7 +225,6 @@ build: v1.12.1
     --ds-color-danger-border-default: #ce4d4d;
     --ds-color-danger-border-strong: #b81a1a;
     --ds-color-danger-text-subtle: #b81a1a;
-    --ds-color-danger-icon-subtle: #b81a1a;
     --ds-color-danger-text-default: #590d0d;
     --ds-color-danger-base-default: #c01b1b;
     --ds-color-danger-base-hover: #9b1616;
@@ -256,7 +250,6 @@ build: v1.12.1
       --ds-color-accent-border-default: #75778e;
       --ds-color-accent-border-strong: #595b77;
       --ds-color-accent-text-subtle: #595b77;
-      --ds-color-accent-icon-subtle: #595b77;
       --ds-color-accent-text-default: #25284c;
       --ds-color-accent-base-default: #00042e;
       --ds-color-accent-base-hover: #151940;
@@ -273,7 +266,6 @@ build: v1.12.1
       --ds-color-neutral-border-default: #74797e;
       --ds-color-neutral-border-strong: #585e64;
       --ds-color-neutral-text-subtle: #585e64;
-      --ds-color-neutral-icon-subtle: #585e64;
       --ds-color-neutral-text-default: #242c34;
       --ds-color-neutral-base-default: #1d252d;
       --ds-color-neutral-base-hover: #2f363d;
@@ -290,7 +282,6 @@ build: v1.12.1
       --ds-color-support1-border-default: #8060ec;
       --ds-color-support1-border-strong: #6244cb;
       --ds-color-support1-text-subtle: #6244cb;
-      --ds-color-support1-icon-subtle: #6244cb;
       --ds-color-support1-text-default: #2e2060;
       --ds-color-support1-base-default: #714eea;
       --ds-color-support1-base-hover: #5d40c0;
@@ -307,7 +298,6 @@ build: v1.12.1
       --ds-color-info-border-default: #1f7dc5;
       --ds-color-info-border-strong: #0860a3;
       --ds-color-info-text-subtle: #0860a3;
-      --ds-color-info-icon-subtle: #0860a3;
       --ds-color-info-text-default: #042d4d;
       --ds-color-info-base-default: #0a71c0;
       --ds-color-info-base-hover: #085d9f;
@@ -324,7 +314,6 @@ build: v1.12.1
       --ds-color-success-border-default: #108c22;
       --ds-color-success-border-strong: #056d13;
       --ds-color-success-text-subtle: #056d13;
-      --ds-color-success-icon-subtle: #056d13;
       --ds-color-success-text-default: #023409;
       --ds-color-success-base-default: #068718;
       --ds-color-success-base-hover: #057014;
@@ -341,7 +330,6 @@ build: v1.12.1
       --ds-color-warning-border-default: #a56d13;
       --ds-color-warning-border-strong: #80540f;
       --ds-color-warning-text-subtle: #80540f;
-      --ds-color-warning-icon-subtle: #80540f;
       --ds-color-warning-text-default: #3c2807;
       --ds-color-warning-base-default: #ea9b1b;
       --ds-color-warning-base-hover: #cd8818;
@@ -358,7 +346,6 @@ build: v1.12.1
       --ds-color-danger-border-default: #ce4d4d;
       --ds-color-danger-border-strong: #b81a1a;
       --ds-color-danger-text-subtle: #b81a1a;
-      --ds-color-danger-icon-subtle: #b81a1a;
       --ds-color-danger-text-default: #590d0d;
       --ds-color-danger-base-default: #c01b1b;
       --ds-color-danger-base-hover: #9b1616;
@@ -570,7 +557,6 @@ build: v1.12.1
     --ds-color-accent-border-default: #7e818f;
     --ds-color-accent-border-strong: #a5a7b1;
     --ds-color-accent-text-subtle: #a5a7b1;
-    --ds-color-accent-icon-subtle: #a5a7b1;
     --ds-color-accent-text-default: #ececee;
     --ds-color-accent-base-default: #a9aab8;
     --ds-color-accent-base-hover: #9395a7;
@@ -587,7 +573,6 @@ build: v1.12.1
     --ds-color-neutral-border-default: #7e8285;
     --ds-color-neutral-border-strong: #a6a8aa;
     --ds-color-neutral-text-subtle: #a6a8aa;
-    --ds-color-neutral-icon-subtle: #a6a8aa;
     --ds-color-neutral-text-default: #ececed;
     --ds-color-neutral-base-default: #a8abae;
     --ds-color-neutral-base-hover: #93979a;
@@ -604,7 +589,6 @@ build: v1.12.1
     --ds-color-support1-border-default: #8375cf;
     --ds-color-support1-border-strong: #aaa0de;
     --ds-color-support1-text-subtle: #aaa0de;
-    --ds-color-support1-icon-subtle: #aaa0de;
     --ds-color-support1-text-default: #edebf8;
     --ds-color-support1-base-default: #896cee;
     --ds-color-support1-base-hover: #9f87f1;
@@ -621,7 +605,6 @@ build: v1.12.1
     --ds-color-info-border-default: #5585b4;
     --ds-color-info-border-strong: #8aabcb;
     --ds-color-info-text-subtle: #8aabcb;
-    --ds-color-info-icon-subtle: #8aabcb;
     --ds-color-info-text-default: #e6edf4;
     --ds-color-info-base-default: #2d85c9;
     --ds-color-info-base-hover: #519ad2;
@@ -638,7 +621,6 @@ build: v1.12.1
     --ds-color-success-border-default: #528f52;
     --ds-color-success-border-strong: #89b289;
     --ds-color-success-text-subtle: #89b289;
-    --ds-color-success-icon-subtle: #89b289;
     --ds-color-success-text-default: #e6efe6;
     --ds-color-success-base-default: #138d24;
     --ds-color-success-base-hover: #3ca14b;
@@ -655,7 +637,6 @@ build: v1.12.1
     --ds-color-warning-border-default: #a37a46;
     --ds-color-warning-border-strong: #d39e5b;
     --ds-color-warning-text-subtle: #d39e5b;
-    --ds-color-warning-icon-subtle: #d39e5b;
     --ds-color-warning-text-default: #f7ebdb;
     --ds-color-warning-base-default: #60400b;
     --ds-color-warning-base-hover: #7a510e;
@@ -672,7 +653,6 @@ build: v1.12.1
     --ds-color-danger-border-default: #bc6b64;
     --ds-color-danger-border-strong: #d19a96;
     --ds-color-danger-text-subtle: #d19a96;
-    --ds-color-danger-icon-subtle: #d19a96;
     --ds-color-danger-text-default: #f5eae9;
     --ds-color-danger-base-default: #d76e6e;
     --ds-color-danger-base-hover: #df8b8b;
@@ -698,7 +678,6 @@ build: v1.12.1
       --ds-color-accent-border-default: #7e818f;
       --ds-color-accent-border-strong: #a5a7b1;
       --ds-color-accent-text-subtle: #a5a7b1;
-      --ds-color-accent-icon-subtle: #a5a7b1;
       --ds-color-accent-text-default: #ececee;
       --ds-color-accent-base-default: #a9aab8;
       --ds-color-accent-base-hover: #9395a7;
@@ -715,7 +694,6 @@ build: v1.12.1
       --ds-color-neutral-border-default: #7e8285;
       --ds-color-neutral-border-strong: #a6a8aa;
       --ds-color-neutral-text-subtle: #a6a8aa;
-      --ds-color-neutral-icon-subtle: #a6a8aa;
       --ds-color-neutral-text-default: #ececed;
       --ds-color-neutral-base-default: #a8abae;
       --ds-color-neutral-base-hover: #93979a;
@@ -732,7 +710,6 @@ build: v1.12.1
       --ds-color-support1-border-default: #8375cf;
       --ds-color-support1-border-strong: #aaa0de;
       --ds-color-support1-text-subtle: #aaa0de;
-      --ds-color-support1-icon-subtle: #aaa0de;
       --ds-color-support1-text-default: #edebf8;
       --ds-color-support1-base-default: #896cee;
       --ds-color-support1-base-hover: #9f87f1;
@@ -749,7 +726,6 @@ build: v1.12.1
       --ds-color-info-border-default: #5585b4;
       --ds-color-info-border-strong: #8aabcb;
       --ds-color-info-text-subtle: #8aabcb;
-      --ds-color-info-icon-subtle: #8aabcb;
       --ds-color-info-text-default: #e6edf4;
       --ds-color-info-base-default: #2d85c9;
       --ds-color-info-base-hover: #519ad2;
@@ -766,7 +742,6 @@ build: v1.12.1
       --ds-color-success-border-default: #528f52;
       --ds-color-success-border-strong: #89b289;
       --ds-color-success-text-subtle: #89b289;
-      --ds-color-success-icon-subtle: #89b289;
       --ds-color-success-text-default: #e6efe6;
       --ds-color-success-base-default: #138d24;
       --ds-color-success-base-hover: #3ca14b;
@@ -783,7 +758,6 @@ build: v1.12.1
       --ds-color-warning-border-default: #a37a46;
       --ds-color-warning-border-strong: #d39e5b;
       --ds-color-warning-text-subtle: #d39e5b;
-      --ds-color-warning-icon-subtle: #d39e5b;
       --ds-color-warning-text-default: #f7ebdb;
       --ds-color-warning-base-default: #60400b;
       --ds-color-warning-base-hover: #7a510e;
@@ -800,7 +774,6 @@ build: v1.12.1
       --ds-color-danger-border-default: #bc6b64;
       --ds-color-danger-border-strong: #d19a96;
       --ds-color-danger-text-subtle: #d19a96;
-      --ds-color-danger-icon-subtle: #d19a96;
       --ds-color-danger-text-default: #f5eae9;
       --ds-color-danger-base-default: #d76e6e;
       --ds-color-danger-base-hover: #df8b8b;
@@ -917,7 +890,6 @@ build: v1.12.1
     --ds-color-border-default: var(--ds-color-accent-border-default);
     --ds-color-border-strong: var(--ds-color-accent-border-strong);
     --ds-color-text-subtle: var(--ds-color-accent-text-subtle);
-    --ds-color-icon-subtle: var(--ds-color-accent-icon-subtle);
     --ds-color-text-default: var(--ds-color-accent-text-default);
     --ds-color-base-default: var(--ds-color-accent-base-default);
     --ds-color-base-hover: var(--ds-color-accent-base-hover);
@@ -944,7 +916,6 @@ build: v1.12.1
     --ds-color-border-default: var(--ds-color-danger-border-default);
     --ds-color-border-strong: var(--ds-color-danger-border-strong);
     --ds-color-text-subtle: var(--ds-color-danger-text-subtle);
-    --ds-color-icon-subtle: var(--ds-color-danger-icon-subtle);
     --ds-color-text-default: var(--ds-color-danger-text-default);
     --ds-color-base-default: var(--ds-color-danger-base-default);
     --ds-color-base-hover: var(--ds-color-danger-base-hover);
@@ -971,7 +942,6 @@ build: v1.12.1
     --ds-color-border-default: var(--ds-color-info-border-default);
     --ds-color-border-strong: var(--ds-color-info-border-strong);
     --ds-color-text-subtle: var(--ds-color-info-text-subtle);
-    --ds-color-icon-subtle: var(--ds-color-info-icon-subtle);
     --ds-color-text-default: var(--ds-color-info-text-default);
     --ds-color-base-default: var(--ds-color-info-base-default);
     --ds-color-base-hover: var(--ds-color-info-base-hover);
@@ -996,7 +966,6 @@ build: v1.12.1
     --ds-color-border-default: var(--ds-color-neutral-border-default);
     --ds-color-border-strong: var(--ds-color-neutral-border-strong);
     --ds-color-text-subtle: var(--ds-color-neutral-text-subtle);
-    --ds-color-icon-subtle: var(--ds-color-neutral-icon-subtle);
     --ds-color-text-default: var(--ds-color-neutral-text-default);
     --ds-color-base-default: var(--ds-color-neutral-base-default);
     --ds-color-base-hover: var(--ds-color-neutral-base-hover);
@@ -1023,7 +992,6 @@ build: v1.12.1
     --ds-color-border-default: var(--ds-color-success-border-default);
     --ds-color-border-strong: var(--ds-color-success-border-strong);
     --ds-color-text-subtle: var(--ds-color-success-text-subtle);
-    --ds-color-icon-subtle: var(--ds-color-success-icon-subtle);
     --ds-color-text-default: var(--ds-color-success-text-default);
     --ds-color-base-default: var(--ds-color-success-base-default);
     --ds-color-base-hover: var(--ds-color-success-base-hover);
@@ -1050,7 +1018,6 @@ build: v1.12.1
     --ds-color-border-default: var(--ds-color-support1-border-default);
     --ds-color-border-strong: var(--ds-color-support1-border-strong);
     --ds-color-text-subtle: var(--ds-color-support1-text-subtle);
-    --ds-color-icon-subtle: var(--ds-color-support1-icon-subtle);
     --ds-color-text-default: var(--ds-color-support1-text-default);
     --ds-color-base-default: var(--ds-color-support1-base-default);
     --ds-color-base-hover: var(--ds-color-support1-base-hover);
@@ -1077,7 +1044,6 @@ build: v1.12.1
     --ds-color-border-default: var(--ds-color-warning-border-default);
     --ds-color-border-strong: var(--ds-color-warning-border-strong);
     --ds-color-text-subtle: var(--ds-color-warning-text-subtle);
-    --ds-color-icon-subtle: var(--ds-color-warning-icon-subtle);
     --ds-color-text-default: var(--ds-color-warning-text-default);
     --ds-color-base-default: var(--ds-color-warning-base-default);
     --ds-color-base-hover: var(--ds-color-warning-base-hover);

--- a/packages/themes/src/themes/minkommune.css
+++ b/packages/themes/src/themes/minkommune.css
@@ -917,7 +917,7 @@ build: v1.12.1
     --ds-color-border-default: var(--ds-color-accent-border-default);
     --ds-color-border-strong: var(--ds-color-accent-border-strong);
     --ds-color-text-subtle: var(--ds-color-accent-text-subtle);
-    --ds-color-icon-subtle: var(--ds-color-accent-text-subtle);
+    --ds-color-icon-subtle: var(--ds-color-accent-icon-subtle);
     --ds-color-text-default: var(--ds-color-accent-text-default);
     --ds-color-base-default: var(--ds-color-accent-base-default);
     --ds-color-base-hover: var(--ds-color-accent-base-hover);
@@ -1050,7 +1050,7 @@ build: v1.12.1
     --ds-color-border-default: var(--ds-color-support1-border-default);
     --ds-color-border-strong: var(--ds-color-support1-border-strong);
     --ds-color-text-subtle: var(--ds-color-support1-text-subtle);
-    --ds-color-icon-subtle: var(--ds-color-support1-text-subtle);
+    --ds-color-icon-subtle: var(--ds-color-support1-icon-subtle);
     --ds-color-text-default: var(--ds-color-support1-text-default);
     --ds-color-base-default: var(--ds-color-support1-base-default);
     --ds-color-base-hover: var(--ds-color-support1-base-hover);

--- a/packages/themes/src/themes/minkommune.css
+++ b/packages/themes/src/themes/minkommune.css
@@ -1,7 +1,6 @@
 @charset "UTF-8";
 /*
 build: v1.12.1
-design-tokens: v1.12.1
 */
 
 @layer ds.theme.size-mode {
@@ -129,6 +128,7 @@ design-tokens: v1.12.1
     --ds-color-accent-border-default: #75778e;
     --ds-color-accent-border-strong: #595b77;
     --ds-color-accent-text-subtle: #595b77;
+    --ds-color-accent-icon-subtle: #595b77;
     --ds-color-accent-text-default: #25284c;
     --ds-color-accent-base-default: #00042e;
     --ds-color-accent-base-hover: #151940;
@@ -145,6 +145,7 @@ design-tokens: v1.12.1
     --ds-color-neutral-border-default: #74797e;
     --ds-color-neutral-border-strong: #585e64;
     --ds-color-neutral-text-subtle: #585e64;
+    --ds-color-neutral-icon-subtle: #585e64;
     --ds-color-neutral-text-default: #242c34;
     --ds-color-neutral-base-default: #1d252d;
     --ds-color-neutral-base-hover: #2f363d;
@@ -161,6 +162,7 @@ design-tokens: v1.12.1
     --ds-color-support1-border-default: #8060ec;
     --ds-color-support1-border-strong: #6244cb;
     --ds-color-support1-text-subtle: #6244cb;
+    --ds-color-support1-icon-subtle: #6244cb;
     --ds-color-support1-text-default: #2e2060;
     --ds-color-support1-base-default: #714eea;
     --ds-color-support1-base-hover: #5d40c0;
@@ -177,6 +179,7 @@ design-tokens: v1.12.1
     --ds-color-info-border-default: #1f7dc5;
     --ds-color-info-border-strong: #0860a3;
     --ds-color-info-text-subtle: #0860a3;
+    --ds-color-info-icon-subtle: #0860a3;
     --ds-color-info-text-default: #042d4d;
     --ds-color-info-base-default: #0a71c0;
     --ds-color-info-base-hover: #085d9f;
@@ -193,6 +196,7 @@ design-tokens: v1.12.1
     --ds-color-success-border-default: #108c22;
     --ds-color-success-border-strong: #056d13;
     --ds-color-success-text-subtle: #056d13;
+    --ds-color-success-icon-subtle: #056d13;
     --ds-color-success-text-default: #023409;
     --ds-color-success-base-default: #068718;
     --ds-color-success-base-hover: #057014;
@@ -209,6 +213,7 @@ design-tokens: v1.12.1
     --ds-color-warning-border-default: #a56d13;
     --ds-color-warning-border-strong: #80540f;
     --ds-color-warning-text-subtle: #80540f;
+    --ds-color-warning-icon-subtle: #80540f;
     --ds-color-warning-text-default: #3c2807;
     --ds-color-warning-base-default: #ea9b1b;
     --ds-color-warning-base-hover: #cd8818;
@@ -225,6 +230,7 @@ design-tokens: v1.12.1
     --ds-color-danger-border-default: #ce4d4d;
     --ds-color-danger-border-strong: #b81a1a;
     --ds-color-danger-text-subtle: #b81a1a;
+    --ds-color-danger-icon-subtle: #b81a1a;
     --ds-color-danger-text-default: #590d0d;
     --ds-color-danger-base-default: #c01b1b;
     --ds-color-danger-base-hover: #9b1616;
@@ -250,6 +256,7 @@ design-tokens: v1.12.1
       --ds-color-accent-border-default: #75778e;
       --ds-color-accent-border-strong: #595b77;
       --ds-color-accent-text-subtle: #595b77;
+      --ds-color-accent-icon-subtle: #595b77;
       --ds-color-accent-text-default: #25284c;
       --ds-color-accent-base-default: #00042e;
       --ds-color-accent-base-hover: #151940;
@@ -266,6 +273,7 @@ design-tokens: v1.12.1
       --ds-color-neutral-border-default: #74797e;
       --ds-color-neutral-border-strong: #585e64;
       --ds-color-neutral-text-subtle: #585e64;
+      --ds-color-neutral-icon-subtle: #585e64;
       --ds-color-neutral-text-default: #242c34;
       --ds-color-neutral-base-default: #1d252d;
       --ds-color-neutral-base-hover: #2f363d;
@@ -282,6 +290,7 @@ design-tokens: v1.12.1
       --ds-color-support1-border-default: #8060ec;
       --ds-color-support1-border-strong: #6244cb;
       --ds-color-support1-text-subtle: #6244cb;
+      --ds-color-support1-icon-subtle: #6244cb;
       --ds-color-support1-text-default: #2e2060;
       --ds-color-support1-base-default: #714eea;
       --ds-color-support1-base-hover: #5d40c0;
@@ -298,6 +307,7 @@ design-tokens: v1.12.1
       --ds-color-info-border-default: #1f7dc5;
       --ds-color-info-border-strong: #0860a3;
       --ds-color-info-text-subtle: #0860a3;
+      --ds-color-info-icon-subtle: #0860a3;
       --ds-color-info-text-default: #042d4d;
       --ds-color-info-base-default: #0a71c0;
       --ds-color-info-base-hover: #085d9f;
@@ -314,6 +324,7 @@ design-tokens: v1.12.1
       --ds-color-success-border-default: #108c22;
       --ds-color-success-border-strong: #056d13;
       --ds-color-success-text-subtle: #056d13;
+      --ds-color-success-icon-subtle: #056d13;
       --ds-color-success-text-default: #023409;
       --ds-color-success-base-default: #068718;
       --ds-color-success-base-hover: #057014;
@@ -330,6 +341,7 @@ design-tokens: v1.12.1
       --ds-color-warning-border-default: #a56d13;
       --ds-color-warning-border-strong: #80540f;
       --ds-color-warning-text-subtle: #80540f;
+      --ds-color-warning-icon-subtle: #80540f;
       --ds-color-warning-text-default: #3c2807;
       --ds-color-warning-base-default: #ea9b1b;
       --ds-color-warning-base-hover: #cd8818;
@@ -346,6 +358,7 @@ design-tokens: v1.12.1
       --ds-color-danger-border-default: #ce4d4d;
       --ds-color-danger-border-strong: #b81a1a;
       --ds-color-danger-text-subtle: #b81a1a;
+      --ds-color-danger-icon-subtle: #b81a1a;
       --ds-color-danger-text-default: #590d0d;
       --ds-color-danger-base-default: #c01b1b;
       --ds-color-danger-base-hover: #9b1616;
@@ -557,6 +570,7 @@ design-tokens: v1.12.1
     --ds-color-accent-border-default: #7e818f;
     --ds-color-accent-border-strong: #a5a7b1;
     --ds-color-accent-text-subtle: #a5a7b1;
+    --ds-color-accent-icon-subtle: #a5a7b1;
     --ds-color-accent-text-default: #ececee;
     --ds-color-accent-base-default: #a9aab8;
     --ds-color-accent-base-hover: #9395a7;
@@ -573,6 +587,7 @@ design-tokens: v1.12.1
     --ds-color-neutral-border-default: #7e8285;
     --ds-color-neutral-border-strong: #a6a8aa;
     --ds-color-neutral-text-subtle: #a6a8aa;
+    --ds-color-neutral-icon-subtle: #a6a8aa;
     --ds-color-neutral-text-default: #ececed;
     --ds-color-neutral-base-default: #a8abae;
     --ds-color-neutral-base-hover: #93979a;
@@ -589,6 +604,7 @@ design-tokens: v1.12.1
     --ds-color-support1-border-default: #8375cf;
     --ds-color-support1-border-strong: #aaa0de;
     --ds-color-support1-text-subtle: #aaa0de;
+    --ds-color-support1-icon-subtle: #aaa0de;
     --ds-color-support1-text-default: #edebf8;
     --ds-color-support1-base-default: #896cee;
     --ds-color-support1-base-hover: #9f87f1;
@@ -605,6 +621,7 @@ design-tokens: v1.12.1
     --ds-color-info-border-default: #5585b4;
     --ds-color-info-border-strong: #8aabcb;
     --ds-color-info-text-subtle: #8aabcb;
+    --ds-color-info-icon-subtle: #8aabcb;
     --ds-color-info-text-default: #e6edf4;
     --ds-color-info-base-default: #2d85c9;
     --ds-color-info-base-hover: #519ad2;
@@ -621,6 +638,7 @@ design-tokens: v1.12.1
     --ds-color-success-border-default: #528f52;
     --ds-color-success-border-strong: #89b289;
     --ds-color-success-text-subtle: #89b289;
+    --ds-color-success-icon-subtle: #89b289;
     --ds-color-success-text-default: #e6efe6;
     --ds-color-success-base-default: #138d24;
     --ds-color-success-base-hover: #3ca14b;
@@ -637,6 +655,7 @@ design-tokens: v1.12.1
     --ds-color-warning-border-default: #a37a46;
     --ds-color-warning-border-strong: #d39e5b;
     --ds-color-warning-text-subtle: #d39e5b;
+    --ds-color-warning-icon-subtle: #d39e5b;
     --ds-color-warning-text-default: #f7ebdb;
     --ds-color-warning-base-default: #60400b;
     --ds-color-warning-base-hover: #7a510e;
@@ -653,6 +672,7 @@ design-tokens: v1.12.1
     --ds-color-danger-border-default: #bc6b64;
     --ds-color-danger-border-strong: #d19a96;
     --ds-color-danger-text-subtle: #d19a96;
+    --ds-color-danger-icon-subtle: #d19a96;
     --ds-color-danger-text-default: #f5eae9;
     --ds-color-danger-base-default: #d76e6e;
     --ds-color-danger-base-hover: #df8b8b;
@@ -678,6 +698,7 @@ design-tokens: v1.12.1
       --ds-color-accent-border-default: #7e818f;
       --ds-color-accent-border-strong: #a5a7b1;
       --ds-color-accent-text-subtle: #a5a7b1;
+      --ds-color-accent-icon-subtle: #a5a7b1;
       --ds-color-accent-text-default: #ececee;
       --ds-color-accent-base-default: #a9aab8;
       --ds-color-accent-base-hover: #9395a7;
@@ -694,6 +715,7 @@ design-tokens: v1.12.1
       --ds-color-neutral-border-default: #7e8285;
       --ds-color-neutral-border-strong: #a6a8aa;
       --ds-color-neutral-text-subtle: #a6a8aa;
+      --ds-color-neutral-icon-subtle: #a6a8aa;
       --ds-color-neutral-text-default: #ececed;
       --ds-color-neutral-base-default: #a8abae;
       --ds-color-neutral-base-hover: #93979a;
@@ -710,6 +732,7 @@ design-tokens: v1.12.1
       --ds-color-support1-border-default: #8375cf;
       --ds-color-support1-border-strong: #aaa0de;
       --ds-color-support1-text-subtle: #aaa0de;
+      --ds-color-support1-icon-subtle: #aaa0de;
       --ds-color-support1-text-default: #edebf8;
       --ds-color-support1-base-default: #896cee;
       --ds-color-support1-base-hover: #9f87f1;
@@ -726,6 +749,7 @@ design-tokens: v1.12.1
       --ds-color-info-border-default: #5585b4;
       --ds-color-info-border-strong: #8aabcb;
       --ds-color-info-text-subtle: #8aabcb;
+      --ds-color-info-icon-subtle: #8aabcb;
       --ds-color-info-text-default: #e6edf4;
       --ds-color-info-base-default: #2d85c9;
       --ds-color-info-base-hover: #519ad2;
@@ -742,6 +766,7 @@ design-tokens: v1.12.1
       --ds-color-success-border-default: #528f52;
       --ds-color-success-border-strong: #89b289;
       --ds-color-success-text-subtle: #89b289;
+      --ds-color-success-icon-subtle: #89b289;
       --ds-color-success-text-default: #e6efe6;
       --ds-color-success-base-default: #138d24;
       --ds-color-success-base-hover: #3ca14b;
@@ -758,6 +783,7 @@ design-tokens: v1.12.1
       --ds-color-warning-border-default: #a37a46;
       --ds-color-warning-border-strong: #d39e5b;
       --ds-color-warning-text-subtle: #d39e5b;
+      --ds-color-warning-icon-subtle: #d39e5b;
       --ds-color-warning-text-default: #f7ebdb;
       --ds-color-warning-base-default: #60400b;
       --ds-color-warning-base-hover: #7a510e;
@@ -774,6 +800,7 @@ design-tokens: v1.12.1
       --ds-color-danger-border-default: #bc6b64;
       --ds-color-danger-border-strong: #d19a96;
       --ds-color-danger-text-subtle: #d19a96;
+      --ds-color-danger-icon-subtle: #d19a96;
       --ds-color-danger-text-default: #f5eae9;
       --ds-color-danger-base-default: #d76e6e;
       --ds-color-danger-base-hover: #df8b8b;
@@ -890,6 +917,7 @@ design-tokens: v1.12.1
     --ds-color-border-default: var(--ds-color-accent-border-default);
     --ds-color-border-strong: var(--ds-color-accent-border-strong);
     --ds-color-text-subtle: var(--ds-color-accent-text-subtle);
+    --ds-color-icon-subtle: var(--ds-color-accent-text-subtle);
     --ds-color-text-default: var(--ds-color-accent-text-default);
     --ds-color-base-default: var(--ds-color-accent-base-default);
     --ds-color-base-hover: var(--ds-color-accent-base-hover);
@@ -916,6 +944,7 @@ design-tokens: v1.12.1
     --ds-color-border-default: var(--ds-color-danger-border-default);
     --ds-color-border-strong: var(--ds-color-danger-border-strong);
     --ds-color-text-subtle: var(--ds-color-danger-text-subtle);
+    --ds-color-icon-subtle: var(--ds-color-danger-icon-subtle);
     --ds-color-text-default: var(--ds-color-danger-text-default);
     --ds-color-base-default: var(--ds-color-danger-base-default);
     --ds-color-base-hover: var(--ds-color-danger-base-hover);
@@ -942,6 +971,7 @@ design-tokens: v1.12.1
     --ds-color-border-default: var(--ds-color-info-border-default);
     --ds-color-border-strong: var(--ds-color-info-border-strong);
     --ds-color-text-subtle: var(--ds-color-info-text-subtle);
+    --ds-color-icon-subtle: var(--ds-color-info-icon-subtle);
     --ds-color-text-default: var(--ds-color-info-text-default);
     --ds-color-base-default: var(--ds-color-info-base-default);
     --ds-color-base-hover: var(--ds-color-info-base-hover);
@@ -966,6 +996,7 @@ design-tokens: v1.12.1
     --ds-color-border-default: var(--ds-color-neutral-border-default);
     --ds-color-border-strong: var(--ds-color-neutral-border-strong);
     --ds-color-text-subtle: var(--ds-color-neutral-text-subtle);
+    --ds-color-icon-subtle: var(--ds-color-neutral-icon-subtle);
     --ds-color-text-default: var(--ds-color-neutral-text-default);
     --ds-color-base-default: var(--ds-color-neutral-base-default);
     --ds-color-base-hover: var(--ds-color-neutral-base-hover);
@@ -992,6 +1023,7 @@ design-tokens: v1.12.1
     --ds-color-border-default: var(--ds-color-success-border-default);
     --ds-color-border-strong: var(--ds-color-success-border-strong);
     --ds-color-text-subtle: var(--ds-color-success-text-subtle);
+    --ds-color-icon-subtle: var(--ds-color-success-icon-subtle);
     --ds-color-text-default: var(--ds-color-success-text-default);
     --ds-color-base-default: var(--ds-color-success-base-default);
     --ds-color-base-hover: var(--ds-color-success-base-hover);
@@ -1018,6 +1050,7 @@ design-tokens: v1.12.1
     --ds-color-border-default: var(--ds-color-support1-border-default);
     --ds-color-border-strong: var(--ds-color-support1-border-strong);
     --ds-color-text-subtle: var(--ds-color-support1-text-subtle);
+    --ds-color-icon-subtle: var(--ds-color-support1-text-subtle);
     --ds-color-text-default: var(--ds-color-support1-text-default);
     --ds-color-base-default: var(--ds-color-support1-base-default);
     --ds-color-base-hover: var(--ds-color-support1-base-hover);
@@ -1044,6 +1077,7 @@ design-tokens: v1.12.1
     --ds-color-border-default: var(--ds-color-warning-border-default);
     --ds-color-border-strong: var(--ds-color-warning-border-strong);
     --ds-color-text-subtle: var(--ds-color-warning-text-subtle);
+    --ds-color-icon-subtle: var(--ds-color-warning-icon-subtle);
     --ds-color-text-default: var(--ds-color-warning-text-default);
     --ds-color-base-default: var(--ds-color-warning-base-default);
     --ds-color-base-hover: var(--ds-color-warning-base-hover);

--- a/packages/themes/src/themes/minkommune.css
+++ b/packages/themes/src/themes/minkommune.css
@@ -129,6 +129,7 @@ design-tokens: v1.12.1
     --ds-color-accent-border-default: #75778e;
     --ds-color-accent-border-strong: #595b77;
     --ds-color-accent-text-subtle: #595b77;
+    --ds-color-accent-icon-subtle: #595b77;
     --ds-color-accent-text-default: #25284c;
     --ds-color-accent-base-default: #00042e;
     --ds-color-accent-base-hover: #151940;
@@ -145,6 +146,7 @@ design-tokens: v1.12.1
     --ds-color-neutral-border-default: #74797e;
     --ds-color-neutral-border-strong: #585e64;
     --ds-color-neutral-text-subtle: #585e64;
+    --ds-color-neutral-icon-subtle: #585e64;
     --ds-color-neutral-text-default: #242c34;
     --ds-color-neutral-base-default: #1d252d;
     --ds-color-neutral-base-hover: #2f363d;
@@ -161,6 +163,7 @@ design-tokens: v1.12.1
     --ds-color-support1-border-default: #8060ec;
     --ds-color-support1-border-strong: #6244cb;
     --ds-color-support1-text-subtle: #6244cb;
+    --ds-color-support1-icon-subtle: #6244cb;
     --ds-color-support1-text-default: #2e2060;
     --ds-color-support1-base-default: #714eea;
     --ds-color-support1-base-hover: #5d40c0;
@@ -177,6 +180,7 @@ design-tokens: v1.12.1
     --ds-color-info-border-default: #1f7dc5;
     --ds-color-info-border-strong: #0860a3;
     --ds-color-info-text-subtle: #0860a3;
+    --ds-color-info-icon-subtle: #0860a3;
     --ds-color-info-text-default: #042d4d;
     --ds-color-info-base-default: #0a71c0;
     --ds-color-info-base-hover: #085d9f;
@@ -193,6 +197,7 @@ design-tokens: v1.12.1
     --ds-color-success-border-default: #108c22;
     --ds-color-success-border-strong: #056d13;
     --ds-color-success-text-subtle: #056d13;
+    --ds-color-success-icon-subtle: #056d13;
     --ds-color-success-text-default: #023409;
     --ds-color-success-base-default: #068718;
     --ds-color-success-base-hover: #057014;
@@ -209,6 +214,7 @@ design-tokens: v1.12.1
     --ds-color-warning-border-default: #a56d13;
     --ds-color-warning-border-strong: #80540f;
     --ds-color-warning-text-subtle: #80540f;
+    --ds-color-warning-icon-subtle: #80540f;
     --ds-color-warning-text-default: #3c2807;
     --ds-color-warning-base-default: #ea9b1b;
     --ds-color-warning-base-hover: #cd8818;
@@ -225,6 +231,7 @@ design-tokens: v1.12.1
     --ds-color-danger-border-default: #ce4d4d;
     --ds-color-danger-border-strong: #b81a1a;
     --ds-color-danger-text-subtle: #b81a1a;
+    --ds-color-danger-icon-subtle: #b81a1a;
     --ds-color-danger-text-default: #590d0d;
     --ds-color-danger-base-default: #c01b1b;
     --ds-color-danger-base-hover: #9b1616;
@@ -250,6 +257,7 @@ design-tokens: v1.12.1
       --ds-color-accent-border-default: #75778e;
       --ds-color-accent-border-strong: #595b77;
       --ds-color-accent-text-subtle: #595b77;
+      --ds-color-accent-icon-subtle: #595b77;
       --ds-color-accent-text-default: #25284c;
       --ds-color-accent-base-default: #00042e;
       --ds-color-accent-base-hover: #151940;
@@ -266,6 +274,7 @@ design-tokens: v1.12.1
       --ds-color-neutral-border-default: #74797e;
       --ds-color-neutral-border-strong: #585e64;
       --ds-color-neutral-text-subtle: #585e64;
+      --ds-color-neutral-icon-subtle: #585e64;
       --ds-color-neutral-text-default: #242c34;
       --ds-color-neutral-base-default: #1d252d;
       --ds-color-neutral-base-hover: #2f363d;
@@ -282,6 +291,7 @@ design-tokens: v1.12.1
       --ds-color-support1-border-default: #8060ec;
       --ds-color-support1-border-strong: #6244cb;
       --ds-color-support1-text-subtle: #6244cb;
+      --ds-color-support1-icon-subtle: #6244cb;
       --ds-color-support1-text-default: #2e2060;
       --ds-color-support1-base-default: #714eea;
       --ds-color-support1-base-hover: #5d40c0;
@@ -298,6 +308,7 @@ design-tokens: v1.12.1
       --ds-color-info-border-default: #1f7dc5;
       --ds-color-info-border-strong: #0860a3;
       --ds-color-info-text-subtle: #0860a3;
+      --ds-color-info-icon-subtle: #0860a3;
       --ds-color-info-text-default: #042d4d;
       --ds-color-info-base-default: #0a71c0;
       --ds-color-info-base-hover: #085d9f;
@@ -314,6 +325,7 @@ design-tokens: v1.12.1
       --ds-color-success-border-default: #108c22;
       --ds-color-success-border-strong: #056d13;
       --ds-color-success-text-subtle: #056d13;
+      --ds-color-success-icon-subtle: #056d13;
       --ds-color-success-text-default: #023409;
       --ds-color-success-base-default: #068718;
       --ds-color-success-base-hover: #057014;
@@ -330,6 +342,7 @@ design-tokens: v1.12.1
       --ds-color-warning-border-default: #a56d13;
       --ds-color-warning-border-strong: #80540f;
       --ds-color-warning-text-subtle: #80540f;
+      --ds-color-warning-icon-subtle: #80540f;
       --ds-color-warning-text-default: #3c2807;
       --ds-color-warning-base-default: #ea9b1b;
       --ds-color-warning-base-hover: #cd8818;
@@ -346,6 +359,7 @@ design-tokens: v1.12.1
       --ds-color-danger-border-default: #ce4d4d;
       --ds-color-danger-border-strong: #b81a1a;
       --ds-color-danger-text-subtle: #b81a1a;
+      --ds-color-danger-icon-subtle: #b81a1a;
       --ds-color-danger-text-default: #590d0d;
       --ds-color-danger-base-default: #c01b1b;
       --ds-color-danger-base-hover: #9b1616;
@@ -557,6 +571,7 @@ design-tokens: v1.12.1
     --ds-color-accent-border-default: #7e818f;
     --ds-color-accent-border-strong: #a5a7b1;
     --ds-color-accent-text-subtle: #a5a7b1;
+    --ds-color-accent-icon-subtle: #a5a7b1;
     --ds-color-accent-text-default: #ececee;
     --ds-color-accent-base-default: #a9aab8;
     --ds-color-accent-base-hover: #9395a7;
@@ -573,6 +588,7 @@ design-tokens: v1.12.1
     --ds-color-neutral-border-default: #7e8285;
     --ds-color-neutral-border-strong: #a6a8aa;
     --ds-color-neutral-text-subtle: #a6a8aa;
+    --ds-color-neutral-icon-subtle: #a6a8aa;
     --ds-color-neutral-text-default: #ececed;
     --ds-color-neutral-base-default: #a8abae;
     --ds-color-neutral-base-hover: #93979a;
@@ -589,6 +605,7 @@ design-tokens: v1.12.1
     --ds-color-support1-border-default: #8375cf;
     --ds-color-support1-border-strong: #aaa0de;
     --ds-color-support1-text-subtle: #aaa0de;
+    --ds-color-support1-icon-subtle: #aaa0de;
     --ds-color-support1-text-default: #edebf8;
     --ds-color-support1-base-default: #896cee;
     --ds-color-support1-base-hover: #9f87f1;
@@ -605,6 +622,7 @@ design-tokens: v1.12.1
     --ds-color-info-border-default: #5585b4;
     --ds-color-info-border-strong: #8aabcb;
     --ds-color-info-text-subtle: #8aabcb;
+    --ds-color-info-icon-subtle: #8aabcb;
     --ds-color-info-text-default: #e6edf4;
     --ds-color-info-base-default: #2d85c9;
     --ds-color-info-base-hover: #519ad2;
@@ -621,6 +639,7 @@ design-tokens: v1.12.1
     --ds-color-success-border-default: #528f52;
     --ds-color-success-border-strong: #89b289;
     --ds-color-success-text-subtle: #89b289;
+    --ds-color-success-icon-subtle: #89b289;
     --ds-color-success-text-default: #e6efe6;
     --ds-color-success-base-default: #138d24;
     --ds-color-success-base-hover: #3ca14b;
@@ -637,6 +656,7 @@ design-tokens: v1.12.1
     --ds-color-warning-border-default: #a37a46;
     --ds-color-warning-border-strong: #d39e5b;
     --ds-color-warning-text-subtle: #d39e5b;
+    --ds-color-warning-icon-subtle: #d39e5b;
     --ds-color-warning-text-default: #f7ebdb;
     --ds-color-warning-base-default: #60400b;
     --ds-color-warning-base-hover: #7a510e;
@@ -653,6 +673,7 @@ design-tokens: v1.12.1
     --ds-color-danger-border-default: #bc6b64;
     --ds-color-danger-border-strong: #d19a96;
     --ds-color-danger-text-subtle: #d19a96;
+    --ds-color-danger-icon-subtle: #d19a96;
     --ds-color-danger-text-default: #f5eae9;
     --ds-color-danger-base-default: #d76e6e;
     --ds-color-danger-base-hover: #df8b8b;
@@ -678,6 +699,7 @@ design-tokens: v1.12.1
       --ds-color-accent-border-default: #7e818f;
       --ds-color-accent-border-strong: #a5a7b1;
       --ds-color-accent-text-subtle: #a5a7b1;
+      --ds-color-accent-icon-subtle: #a5a7b1;
       --ds-color-accent-text-default: #ececee;
       --ds-color-accent-base-default: #a9aab8;
       --ds-color-accent-base-hover: #9395a7;
@@ -694,6 +716,7 @@ design-tokens: v1.12.1
       --ds-color-neutral-border-default: #7e8285;
       --ds-color-neutral-border-strong: #a6a8aa;
       --ds-color-neutral-text-subtle: #a6a8aa;
+      --ds-color-neutral-icon-subtle: #a6a8aa;
       --ds-color-neutral-text-default: #ececed;
       --ds-color-neutral-base-default: #a8abae;
       --ds-color-neutral-base-hover: #93979a;
@@ -710,6 +733,7 @@ design-tokens: v1.12.1
       --ds-color-support1-border-default: #8375cf;
       --ds-color-support1-border-strong: #aaa0de;
       --ds-color-support1-text-subtle: #aaa0de;
+      --ds-color-support1-icon-subtle: #aaa0de;
       --ds-color-support1-text-default: #edebf8;
       --ds-color-support1-base-default: #896cee;
       --ds-color-support1-base-hover: #9f87f1;
@@ -726,6 +750,7 @@ design-tokens: v1.12.1
       --ds-color-info-border-default: #5585b4;
       --ds-color-info-border-strong: #8aabcb;
       --ds-color-info-text-subtle: #8aabcb;
+      --ds-color-info-icon-subtle: #8aabcb;
       --ds-color-info-text-default: #e6edf4;
       --ds-color-info-base-default: #2d85c9;
       --ds-color-info-base-hover: #519ad2;
@@ -742,6 +767,7 @@ design-tokens: v1.12.1
       --ds-color-success-border-default: #528f52;
       --ds-color-success-border-strong: #89b289;
       --ds-color-success-text-subtle: #89b289;
+      --ds-color-success-icon-subtle: #89b289;
       --ds-color-success-text-default: #e6efe6;
       --ds-color-success-base-default: #138d24;
       --ds-color-success-base-hover: #3ca14b;
@@ -758,6 +784,7 @@ design-tokens: v1.12.1
       --ds-color-warning-border-default: #a37a46;
       --ds-color-warning-border-strong: #d39e5b;
       --ds-color-warning-text-subtle: #d39e5b;
+      --ds-color-warning-icon-subtle: #d39e5b;
       --ds-color-warning-text-default: #f7ebdb;
       --ds-color-warning-base-default: #60400b;
       --ds-color-warning-base-hover: #7a510e;
@@ -774,6 +801,7 @@ design-tokens: v1.12.1
       --ds-color-danger-border-default: #bc6b64;
       --ds-color-danger-border-strong: #d19a96;
       --ds-color-danger-text-subtle: #d19a96;
+      --ds-color-danger-icon-subtle: #d19a96;
       --ds-color-danger-text-default: #f5eae9;
       --ds-color-danger-base-default: #d76e6e;
       --ds-color-danger-base-hover: #df8b8b;
@@ -890,6 +918,7 @@ design-tokens: v1.12.1
     --ds-color-border-default: var(--ds-color-accent-border-default);
     --ds-color-border-strong: var(--ds-color-accent-border-strong);
     --ds-color-text-subtle: var(--ds-color-accent-text-subtle);
+    --ds-color-icon-subtle: var(--ds-color-accent-icon-subtle);
     --ds-color-text-default: var(--ds-color-accent-text-default);
     --ds-color-base-default: var(--ds-color-accent-base-default);
     --ds-color-base-hover: var(--ds-color-accent-base-hover);
@@ -916,6 +945,7 @@ design-tokens: v1.12.1
     --ds-color-border-default: var(--ds-color-danger-border-default);
     --ds-color-border-strong: var(--ds-color-danger-border-strong);
     --ds-color-text-subtle: var(--ds-color-danger-text-subtle);
+    --ds-color-icon-subtle: var(--ds-color-danger-icon-subtle);
     --ds-color-text-default: var(--ds-color-danger-text-default);
     --ds-color-base-default: var(--ds-color-danger-base-default);
     --ds-color-base-hover: var(--ds-color-danger-base-hover);
@@ -942,6 +972,7 @@ design-tokens: v1.12.1
     --ds-color-border-default: var(--ds-color-info-border-default);
     --ds-color-border-strong: var(--ds-color-info-border-strong);
     --ds-color-text-subtle: var(--ds-color-info-text-subtle);
+    --ds-color-icon-subtle: var(--ds-color-info-icon-subtle);
     --ds-color-text-default: var(--ds-color-info-text-default);
     --ds-color-base-default: var(--ds-color-info-base-default);
     --ds-color-base-hover: var(--ds-color-info-base-hover);
@@ -966,6 +997,7 @@ design-tokens: v1.12.1
     --ds-color-border-default: var(--ds-color-neutral-border-default);
     --ds-color-border-strong: var(--ds-color-neutral-border-strong);
     --ds-color-text-subtle: var(--ds-color-neutral-text-subtle);
+    --ds-color-icon-subtle: var(--ds-color-neutral-icon-subtle);
     --ds-color-text-default: var(--ds-color-neutral-text-default);
     --ds-color-base-default: var(--ds-color-neutral-base-default);
     --ds-color-base-hover: var(--ds-color-neutral-base-hover);
@@ -992,6 +1024,7 @@ design-tokens: v1.12.1
     --ds-color-border-default: var(--ds-color-success-border-default);
     --ds-color-border-strong: var(--ds-color-success-border-strong);
     --ds-color-text-subtle: var(--ds-color-success-text-subtle);
+    --ds-color-icon-subtle: var(--ds-color-success-icon-subtle);
     --ds-color-text-default: var(--ds-color-success-text-default);
     --ds-color-base-default: var(--ds-color-success-base-default);
     --ds-color-base-hover: var(--ds-color-success-base-hover);
@@ -1018,6 +1051,7 @@ design-tokens: v1.12.1
     --ds-color-border-default: var(--ds-color-support1-border-default);
     --ds-color-border-strong: var(--ds-color-support1-border-strong);
     --ds-color-text-subtle: var(--ds-color-support1-text-subtle);
+    --ds-color-icon-subtle: var(--ds-color-support1-icon-subtle);
     --ds-color-text-default: var(--ds-color-support1-text-default);
     --ds-color-base-default: var(--ds-color-support1-base-default);
     --ds-color-base-hover: var(--ds-color-support1-base-hover);
@@ -1044,6 +1078,7 @@ design-tokens: v1.12.1
     --ds-color-border-default: var(--ds-color-warning-border-default);
     --ds-color-border-strong: var(--ds-color-warning-border-strong);
     --ds-color-text-subtle: var(--ds-color-warning-text-subtle);
+    --ds-color-icon-subtle: var(--ds-color-warning-icon-subtle);
     --ds-color-text-default: var(--ds-color-warning-text-default);
     --ds-color-base-default: var(--ds-color-warning-base-default);
     --ds-color-base-hover: var(--ds-color-warning-base-hover);

--- a/packages/themes/src/themes/minkommune.tailwind.css
+++ b/packages/themes/src/themes/minkommune.tailwind.css
@@ -18,6 +18,7 @@
   --color-accent-border-default: var(--ds-color-accent-border-default);
   --color-accent-border-strong: var(--ds-color-accent-border-strong);
   --color-accent-border-subtle: var(--ds-color-accent-border-subtle);
+  --color-accent-icon-subtle: var(--ds-color-accent-icon-subtle);
   --color-accent-surface-active: var(--ds-color-accent-surface-active);
   --color-accent-surface-default: var(--ds-color-accent-surface-default);
   --color-accent-surface-hover: var(--ds-color-accent-surface-hover);
@@ -48,12 +49,14 @@
   --color-danger-border-default: var(--ds-color-danger-border-default);
   --color-danger-border-strong: var(--ds-color-danger-border-strong);
   --color-danger-border-subtle: var(--ds-color-danger-border-subtle);
+  --color-danger-icon-subtle: var(--ds-color-danger-icon-subtle);
   --color-danger-surface-active: var(--ds-color-danger-surface-active);
   --color-danger-surface-default: var(--ds-color-danger-surface-default);
   --color-danger-surface-hover: var(--ds-color-danger-surface-hover);
   --color-danger-surface-tinted: var(--ds-color-danger-surface-tinted);
   --color-danger-text-default: var(--ds-color-danger-text-default);
   --color-danger-text-subtle: var(--ds-color-danger-text-subtle);
+  --color-icon-subtle: var(--ds-color-icon-subtle);
   --color-info-background-default: var(--ds-color-info-background-default);
   --color-info-background-tinted: var(--ds-color-info-background-tinted);
   --color-info-base-active: var(--ds-color-info-base-active);
@@ -66,6 +69,7 @@
   --color-info-border-default: var(--ds-color-info-border-default);
   --color-info-border-strong: var(--ds-color-info-border-strong);
   --color-info-border-subtle: var(--ds-color-info-border-subtle);
+  --color-info-icon-subtle: var(--ds-color-info-icon-subtle);
   --color-info-surface-active: var(--ds-color-info-surface-active);
   --color-info-surface-default: var(--ds-color-info-surface-default);
   --color-info-surface-hover: var(--ds-color-info-surface-hover);
@@ -88,6 +92,7 @@
   --color-neutral-border-default: var(--ds-color-neutral-border-default);
   --color-neutral-border-strong: var(--ds-color-neutral-border-strong);
   --color-neutral-border-subtle: var(--ds-color-neutral-border-subtle);
+  --color-neutral-icon-subtle: var(--ds-color-neutral-icon-subtle);
   --color-neutral-surface-active: var(--ds-color-neutral-surface-active);
   --color-neutral-surface-default: var(--ds-color-neutral-surface-default);
   --color-neutral-surface-hover: var(--ds-color-neutral-surface-hover);
@@ -110,6 +115,7 @@
   --color-success-border-default: var(--ds-color-success-border-default);
   --color-success-border-strong: var(--ds-color-success-border-strong);
   --color-success-border-subtle: var(--ds-color-success-border-subtle);
+  --color-success-icon-subtle: var(--ds-color-success-icon-subtle);
   --color-success-surface-active: var(--ds-color-success-surface-active);
   --color-success-surface-default: var(--ds-color-success-surface-default);
   --color-success-surface-hover: var(--ds-color-success-surface-hover);
@@ -134,6 +140,7 @@
   --color-support1-border-default: var(--ds-color-support1-border-default);
   --color-support1-border-strong: var(--ds-color-support1-border-strong);
   --color-support1-border-subtle: var(--ds-color-support1-border-subtle);
+  --color-support1-icon-subtle: var(--ds-color-support1-icon-subtle);
   --color-support1-surface-active: var(--ds-color-support1-surface-active);
   --color-support1-surface-default: var(--ds-color-support1-surface-default);
   --color-support1-surface-hover: var(--ds-color-support1-surface-hover);
@@ -162,6 +169,7 @@
   --color-warning-border-default: var(--ds-color-warning-border-default);
   --color-warning-border-strong: var(--ds-color-warning-border-strong);
   --color-warning-border-subtle: var(--ds-color-warning-border-subtle);
+  --color-warning-icon-subtle: var(--ds-color-warning-icon-subtle);
   --color-warning-surface-active: var(--ds-color-warning-surface-active);
   --color-warning-surface-default: var(--ds-color-warning-surface-default);
   --color-warning-surface-hover: var(--ds-color-warning-surface-hover);

--- a/packages/themes/src/themes/minkommune.tailwind.css
+++ b/packages/themes/src/themes/minkommune.tailwind.css
@@ -18,7 +18,6 @@
   --color-accent-border-default: var(--ds-color-accent-border-default);
   --color-accent-border-strong: var(--ds-color-accent-border-strong);
   --color-accent-border-subtle: var(--ds-color-accent-border-subtle);
-  --color-accent-icon-subtle: var(--ds-color-accent-icon-subtle);
   --color-accent-surface-active: var(--ds-color-accent-surface-active);
   --color-accent-surface-default: var(--ds-color-accent-surface-default);
   --color-accent-surface-hover: var(--ds-color-accent-surface-hover);
@@ -49,14 +48,12 @@
   --color-danger-border-default: var(--ds-color-danger-border-default);
   --color-danger-border-strong: var(--ds-color-danger-border-strong);
   --color-danger-border-subtle: var(--ds-color-danger-border-subtle);
-  --color-danger-icon-subtle: var(--ds-color-danger-icon-subtle);
   --color-danger-surface-active: var(--ds-color-danger-surface-active);
   --color-danger-surface-default: var(--ds-color-danger-surface-default);
   --color-danger-surface-hover: var(--ds-color-danger-surface-hover);
   --color-danger-surface-tinted: var(--ds-color-danger-surface-tinted);
   --color-danger-text-default: var(--ds-color-danger-text-default);
   --color-danger-text-subtle: var(--ds-color-danger-text-subtle);
-  --color-icon-subtle: var(--ds-color-icon-subtle);
   --color-info-background-default: var(--ds-color-info-background-default);
   --color-info-background-tinted: var(--ds-color-info-background-tinted);
   --color-info-base-active: var(--ds-color-info-base-active);
@@ -69,7 +66,6 @@
   --color-info-border-default: var(--ds-color-info-border-default);
   --color-info-border-strong: var(--ds-color-info-border-strong);
   --color-info-border-subtle: var(--ds-color-info-border-subtle);
-  --color-info-icon-subtle: var(--ds-color-info-icon-subtle);
   --color-info-surface-active: var(--ds-color-info-surface-active);
   --color-info-surface-default: var(--ds-color-info-surface-default);
   --color-info-surface-hover: var(--ds-color-info-surface-hover);
@@ -92,7 +88,6 @@
   --color-neutral-border-default: var(--ds-color-neutral-border-default);
   --color-neutral-border-strong: var(--ds-color-neutral-border-strong);
   --color-neutral-border-subtle: var(--ds-color-neutral-border-subtle);
-  --color-neutral-icon-subtle: var(--ds-color-neutral-icon-subtle);
   --color-neutral-surface-active: var(--ds-color-neutral-surface-active);
   --color-neutral-surface-default: var(--ds-color-neutral-surface-default);
   --color-neutral-surface-hover: var(--ds-color-neutral-surface-hover);
@@ -115,7 +110,6 @@
   --color-success-border-default: var(--ds-color-success-border-default);
   --color-success-border-strong: var(--ds-color-success-border-strong);
   --color-success-border-subtle: var(--ds-color-success-border-subtle);
-  --color-success-icon-subtle: var(--ds-color-success-icon-subtle);
   --color-success-surface-active: var(--ds-color-success-surface-active);
   --color-success-surface-default: var(--ds-color-success-surface-default);
   --color-success-surface-hover: var(--ds-color-success-surface-hover);
@@ -140,7 +134,6 @@
   --color-support1-border-default: var(--ds-color-support1-border-default);
   --color-support1-border-strong: var(--ds-color-support1-border-strong);
   --color-support1-border-subtle: var(--ds-color-support1-border-subtle);
-  --color-support1-icon-subtle: var(--ds-color-support1-icon-subtle);
   --color-support1-surface-active: var(--ds-color-support1-surface-active);
   --color-support1-surface-default: var(--ds-color-support1-surface-default);
   --color-support1-surface-hover: var(--ds-color-support1-surface-hover);
@@ -169,7 +162,6 @@
   --color-warning-border-default: var(--ds-color-warning-border-default);
   --color-warning-border-strong: var(--ds-color-warning-border-strong);
   --color-warning-border-subtle: var(--ds-color-warning-border-subtle);
-  --color-warning-icon-subtle: var(--ds-color-warning-icon-subtle);
   --color-warning-surface-active: var(--ds-color-warning-surface-active);
   --color-warning-surface-default: var(--ds-color-warning-surface-default);
   --color-warning-surface-hover: var(--ds-color-warning-surface-hover);
@@ -211,6 +203,7 @@
   --color-border-default: var(--ds-color-border-default);
   --color-border-strong: var(--ds-color-border-strong);
   --color-text-subtle: var(--ds-color-text-subtle);
+  --color-icon-subtle: var(--ds-color-icon-subtle);
   --color-text-default: var(--ds-color-text-default);
   --color-base-default: var(--ds-color-base-default);
   --color-base-hover: var(--ds-color-base-hover);

--- a/packages/themes/src/themes/tilskudd.css
+++ b/packages/themes/src/themes/tilskudd.css
@@ -129,6 +129,7 @@ design-tokens: v1.12.1
     --ds-color-accent-border-default: #a2afb8;
     --ds-color-accent-border-strong: #10171f;
     --ds-color-accent-text-subtle: #53595e;
+    --ds-color-accent-icon-subtle: #53595e;
     --ds-color-accent-text-default: #10171f;
     --ds-color-accent-base-default: #31373d;
     --ds-color-accent-base-hover: #1c242e;
@@ -145,6 +146,7 @@ design-tokens: v1.12.1
     --ds-color-neutral-border-default: #96a396;
     --ds-color-neutral-border-strong: #172915;
     --ds-color-neutral-text-subtle: #495749;
+    --ds-color-neutral-icon-subtle: #495749;
     --ds-color-neutral-text-default: #10171f;
     --ds-color-neutral-base-default: #4d524d;
     --ds-color-neutral-base-hover: #2b2e2b;
@@ -161,6 +163,7 @@ design-tokens: v1.12.1
     --ds-color-support1-border-default: #797979;
     --ds-color-support1-border-strong: #5d5d5d;
     --ds-color-support1-text-subtle: #5d5d5d;
+    --ds-color-support1-icon-subtle: #5d5d5d;
     --ds-color-support1-text-default: #2b2b2b;
     --ds-color-support1-base-default: #ffffff;
     --ds-color-support1-base-hover: #e8e8e8;
@@ -177,6 +180,7 @@ design-tokens: v1.12.1
     --ds-color-info-border-default: #a583cc;
     --ds-color-info-border-strong: #1e1529;
     --ds-color-info-text-subtle: #6b4399;
+    --ds-color-info-icon-subtle: #6b4399;
     --ds-color-info-text-default: #10171f;
     --ds-color-info-base-default: #7529cc;
     --ds-color-info-base-hover: #28163d;
@@ -193,6 +197,7 @@ design-tokens: v1.12.1
     --ds-color-success-border-default: #7bb893;
     --ds-color-success-border-strong: #132419;
     --ds-color-success-text-subtle: #187a40;
+    --ds-color-success-icon-subtle: #187a40;
     --ds-color-success-text-default: #10171f;
     --ds-color-success-base-default: #00cc52;
     --ds-color-success-base-hover: #142e1e;
@@ -209,6 +214,7 @@ design-tokens: v1.12.1
     --ds-color-warning-border-default: #f5c814;
     --ds-color-warning-border-strong: #292515;
     --ds-color-warning-text-subtle: #7a6a27;
+    --ds-color-warning-icon-subtle: #7a6a27;
     --ds-color-warning-text-default: #10171f;
     --ds-color-warning-base-default: #ffcc00;
     --ds-color-warning-base-hover: #382e04;
@@ -225,6 +231,7 @@ design-tokens: v1.12.1
     --ds-color-danger-border-default: #e58198;
     --ds-color-danger-border-strong: #261418;
     --ds-color-danger-text-subtle: #b8002b;
+    --ds-color-danger-icon-subtle: #b8002b;
     --ds-color-danger-text-default: #10171f;
     --ds-color-danger-base-default: #ff2457;
     --ds-color-danger-base-hover: #3d161f;
@@ -250,6 +257,7 @@ design-tokens: v1.12.1
       --ds-color-accent-border-default: #a2afb8;
       --ds-color-accent-border-strong: #10171f;
       --ds-color-accent-text-subtle: #53595e;
+      --ds-color-accent-icon-subtle: #53595e;
       --ds-color-accent-text-default: #10171f;
       --ds-color-accent-base-default: #31373d;
       --ds-color-accent-base-hover: #1c242e;
@@ -266,6 +274,7 @@ design-tokens: v1.12.1
       --ds-color-neutral-border-default: #96a396;
       --ds-color-neutral-border-strong: #172915;
       --ds-color-neutral-text-subtle: #495749;
+      --ds-color-neutral-icon-subtle: #495749;
       --ds-color-neutral-text-default: #10171f;
       --ds-color-neutral-base-default: #4d524d;
       --ds-color-neutral-base-hover: #2b2e2b;
@@ -282,6 +291,7 @@ design-tokens: v1.12.1
       --ds-color-support1-border-default: #797979;
       --ds-color-support1-border-strong: #5d5d5d;
       --ds-color-support1-text-subtle: #5d5d5d;
+      --ds-color-support1-icon-subtle: #5d5d5d;
       --ds-color-support1-text-default: #2b2b2b;
       --ds-color-support1-base-default: #ffffff;
       --ds-color-support1-base-hover: #e8e8e8;
@@ -298,6 +308,7 @@ design-tokens: v1.12.1
       --ds-color-info-border-default: #a583cc;
       --ds-color-info-border-strong: #1e1529;
       --ds-color-info-text-subtle: #6b4399;
+      --ds-color-info-icon-subtle: #6b4399;
       --ds-color-info-text-default: #10171f;
       --ds-color-info-base-default: #7529cc;
       --ds-color-info-base-hover: #28163d;
@@ -314,6 +325,7 @@ design-tokens: v1.12.1
       --ds-color-success-border-default: #7bb893;
       --ds-color-success-border-strong: #132419;
       --ds-color-success-text-subtle: #187a40;
+      --ds-color-success-icon-subtle: #187a40;
       --ds-color-success-text-default: #10171f;
       --ds-color-success-base-default: #00cc52;
       --ds-color-success-base-hover: #142e1e;
@@ -330,6 +342,7 @@ design-tokens: v1.12.1
       --ds-color-warning-border-default: #f5c814;
       --ds-color-warning-border-strong: #292515;
       --ds-color-warning-text-subtle: #7a6a27;
+      --ds-color-warning-icon-subtle: #7a6a27;
       --ds-color-warning-text-default: #10171f;
       --ds-color-warning-base-default: #ffcc00;
       --ds-color-warning-base-hover: #382e04;
@@ -346,6 +359,7 @@ design-tokens: v1.12.1
       --ds-color-danger-border-default: #e58198;
       --ds-color-danger-border-strong: #261418;
       --ds-color-danger-text-subtle: #b8002b;
+      --ds-color-danger-icon-subtle: #b8002b;
       --ds-color-danger-text-default: #10171f;
       --ds-color-danger-base-default: #ff2457;
       --ds-color-danger-base-hover: #3d161f;
@@ -557,6 +571,7 @@ design-tokens: v1.12.1
     --ds-color-accent-border-default: #7f8184;
     --ds-color-accent-border-strong: #a6a8aa;
     --ds-color-accent-text-subtle: #a6a8aa;
+    --ds-color-accent-icon-subtle: #a6a8aa;
     --ds-color-accent-text-default: #ececed;
     --ds-color-accent-base-default: #a9abae;
     --ds-color-accent-base-hover: #93969a;
@@ -573,6 +588,7 @@ design-tokens: v1.12.1
     --ds-color-neutral-border-default: #808280;
     --ds-color-neutral-border-strong: #a7a8a7;
     --ds-color-neutral-text-subtle: #a7a8a7;
+    --ds-color-neutral-icon-subtle: #a7a8a7;
     --ds-color-neutral-text-default: #ececec;
     --ds-color-neutral-base-default: #9ea19e;
     --ds-color-neutral-base-hover: #898c89;
@@ -589,6 +605,7 @@ design-tokens: v1.12.1
     --ds-color-support1-border-default: #818181;
     --ds-color-support1-border-strong: #a8a8a8;
     --ds-color-support1-text-subtle: #a8a8a8;
+    --ds-color-support1-icon-subtle: #a8a8a8;
     --ds-color-support1-text-default: #ececec;
     --ds-color-support1-base-default: #000000;
     --ds-color-support1-base-hover: #181818;
@@ -605,6 +622,7 @@ design-tokens: v1.12.1
     --ds-color-info-border-default: #9173c1;
     --ds-color-info-border-strong: #b39ed4;
     --ds-color-info-text-subtle: #b39ed4;
+    --ds-color-info-icon-subtle: #b39ed4;
     --ds-color-info-text-default: #efeaf6;
     --ds-color-info-base-default: #af83e2;
     --ds-color-info-base-hover: #c19fe8;
@@ -621,6 +639,7 @@ design-tokens: v1.12.1
     --ds-color-success-border-default: #469054;
     --ds-color-success-border-strong: #5bbb6d;
     --ds-color-success-text-subtle: #5bbb6d;
+    --ds-color-success-icon-subtle: #5bbb6d;
     --ds-color-success-text-default: #dcf2e0;
     --ds-color-success-base-default: #004d1f;
     --ds-color-success-base-hover: #006227;
@@ -637,6 +656,7 @@ design-tokens: v1.12.1
     --ds-color-warning-border-default: #957f43;
     --ds-color-warning-border-strong: #c1a557;
     --ds-color-warning-text-subtle: #c1a557;
+    --ds-color-warning-icon-subtle: #c1a557;
     --ds-color-warning-text-default: #faecc4;
     --ds-color-warning-base-default: #302600;
     --ds-color-warning-base-hover: #463800;
@@ -653,6 +673,7 @@ design-tokens: v1.12.1
     --ds-color-danger-border-default: #de5156;
     --ds-color-danger-border-strong: #eb8e91;
     --ds-color-danger-text-subtle: #eb8e91;
+    --ds-color-danger-icon-subtle: #eb8e91;
     --ds-color-danger-text-default: #fbe8e9;
     --ds-color-danger-base-default: #dd0034;
     --ds-color-danger-base-hover: #b7002b;
@@ -678,6 +699,7 @@ design-tokens: v1.12.1
       --ds-color-accent-border-default: #7f8184;
       --ds-color-accent-border-strong: #a6a8aa;
       --ds-color-accent-text-subtle: #a6a8aa;
+      --ds-color-accent-icon-subtle: #a6a8aa;
       --ds-color-accent-text-default: #ececed;
       --ds-color-accent-base-default: #a9abae;
       --ds-color-accent-base-hover: #93969a;
@@ -694,6 +716,7 @@ design-tokens: v1.12.1
       --ds-color-neutral-border-default: #808280;
       --ds-color-neutral-border-strong: #a7a8a7;
       --ds-color-neutral-text-subtle: #a7a8a7;
+      --ds-color-neutral-icon-subtle: #a7a8a7;
       --ds-color-neutral-text-default: #ececec;
       --ds-color-neutral-base-default: #9ea19e;
       --ds-color-neutral-base-hover: #898c89;
@@ -710,6 +733,7 @@ design-tokens: v1.12.1
       --ds-color-support1-border-default: #818181;
       --ds-color-support1-border-strong: #a8a8a8;
       --ds-color-support1-text-subtle: #a8a8a8;
+      --ds-color-support1-icon-subtle: #a8a8a8;
       --ds-color-support1-text-default: #ececec;
       --ds-color-support1-base-default: #000000;
       --ds-color-support1-base-hover: #181818;
@@ -726,6 +750,7 @@ design-tokens: v1.12.1
       --ds-color-info-border-default: #9173c1;
       --ds-color-info-border-strong: #b39ed4;
       --ds-color-info-text-subtle: #b39ed4;
+      --ds-color-info-icon-subtle: #b39ed4;
       --ds-color-info-text-default: #efeaf6;
       --ds-color-info-base-default: #af83e2;
       --ds-color-info-base-hover: #c19fe8;
@@ -742,6 +767,7 @@ design-tokens: v1.12.1
       --ds-color-success-border-default: #469054;
       --ds-color-success-border-strong: #5bbb6d;
       --ds-color-success-text-subtle: #5bbb6d;
+      --ds-color-success-icon-subtle: #5bbb6d;
       --ds-color-success-text-default: #dcf2e0;
       --ds-color-success-base-default: #004d1f;
       --ds-color-success-base-hover: #006227;
@@ -758,6 +784,7 @@ design-tokens: v1.12.1
       --ds-color-warning-border-default: #957f43;
       --ds-color-warning-border-strong: #c1a557;
       --ds-color-warning-text-subtle: #c1a557;
+      --ds-color-warning-icon-subtle: #c1a557;
       --ds-color-warning-text-default: #faecc4;
       --ds-color-warning-base-default: #302600;
       --ds-color-warning-base-hover: #463800;
@@ -774,6 +801,7 @@ design-tokens: v1.12.1
       --ds-color-danger-border-default: #de5156;
       --ds-color-danger-border-strong: #eb8e91;
       --ds-color-danger-text-subtle: #eb8e91;
+      --ds-color-danger-icon-subtle: #eb8e91;
       --ds-color-danger-text-default: #fbe8e9;
       --ds-color-danger-base-default: #dd0034;
       --ds-color-danger-base-hover: #b7002b;
@@ -890,6 +918,7 @@ design-tokens: v1.12.1
     --ds-color-border-default: var(--ds-color-accent-border-default);
     --ds-color-border-strong: var(--ds-color-accent-border-strong);
     --ds-color-text-subtle: var(--ds-color-accent-text-subtle);
+    --ds-color-icon-subtle: var(--ds-color-accent-icon-subtle);
     --ds-color-text-default: var(--ds-color-accent-text-default);
     --ds-color-base-default: var(--ds-color-accent-base-default);
     --ds-color-base-hover: var(--ds-color-accent-base-hover);
@@ -916,6 +945,7 @@ design-tokens: v1.12.1
     --ds-color-border-default: var(--ds-color-danger-border-default);
     --ds-color-border-strong: var(--ds-color-danger-border-strong);
     --ds-color-text-subtle: var(--ds-color-danger-text-subtle);
+    --ds-color-icon-subtle: var(--ds-color-danger-icon-subtle);
     --ds-color-text-default: var(--ds-color-danger-text-default);
     --ds-color-base-default: var(--ds-color-danger-base-default);
     --ds-color-base-hover: var(--ds-color-danger-base-hover);
@@ -942,6 +972,7 @@ design-tokens: v1.12.1
     --ds-color-border-default: var(--ds-color-info-border-default);
     --ds-color-border-strong: var(--ds-color-info-border-strong);
     --ds-color-text-subtle: var(--ds-color-info-text-subtle);
+    --ds-color-icon-subtle: var(--ds-color-info-icon-subtle);
     --ds-color-text-default: var(--ds-color-info-text-default);
     --ds-color-base-default: var(--ds-color-info-base-default);
     --ds-color-base-hover: var(--ds-color-info-base-hover);
@@ -966,6 +997,7 @@ design-tokens: v1.12.1
     --ds-color-border-default: var(--ds-color-neutral-border-default);
     --ds-color-border-strong: var(--ds-color-neutral-border-strong);
     --ds-color-text-subtle: var(--ds-color-neutral-text-subtle);
+    --ds-color-icon-subtle: var(--ds-color-neutral-icon-subtle);
     --ds-color-text-default: var(--ds-color-neutral-text-default);
     --ds-color-base-default: var(--ds-color-neutral-base-default);
     --ds-color-base-hover: var(--ds-color-neutral-base-hover);
@@ -992,6 +1024,7 @@ design-tokens: v1.12.1
     --ds-color-border-default: var(--ds-color-success-border-default);
     --ds-color-border-strong: var(--ds-color-success-border-strong);
     --ds-color-text-subtle: var(--ds-color-success-text-subtle);
+    --ds-color-icon-subtle: var(--ds-color-success-icon-subtle);
     --ds-color-text-default: var(--ds-color-success-text-default);
     --ds-color-base-default: var(--ds-color-success-base-default);
     --ds-color-base-hover: var(--ds-color-success-base-hover);
@@ -1018,6 +1051,7 @@ design-tokens: v1.12.1
     --ds-color-border-default: var(--ds-color-support1-border-default);
     --ds-color-border-strong: var(--ds-color-support1-border-strong);
     --ds-color-text-subtle: var(--ds-color-support1-text-subtle);
+    --ds-color-icon-subtle: var(--ds-color-support1-icon-subtle);
     --ds-color-text-default: var(--ds-color-support1-text-default);
     --ds-color-base-default: var(--ds-color-support1-base-default);
     --ds-color-base-hover: var(--ds-color-support1-base-hover);
@@ -1044,6 +1078,7 @@ design-tokens: v1.12.1
     --ds-color-border-default: var(--ds-color-warning-border-default);
     --ds-color-border-strong: var(--ds-color-warning-border-strong);
     --ds-color-text-subtle: var(--ds-color-warning-text-subtle);
+    --ds-color-icon-subtle: var(--ds-color-warning-icon-subtle);
     --ds-color-text-default: var(--ds-color-warning-text-default);
     --ds-color-base-default: var(--ds-color-warning-base-default);
     --ds-color-base-hover: var(--ds-color-warning-base-hover);

--- a/packages/themes/src/themes/tilskudd.css
+++ b/packages/themes/src/themes/tilskudd.css
@@ -917,7 +917,7 @@ build: v1.12.1
     --ds-color-border-default: var(--ds-color-accent-border-default);
     --ds-color-border-strong: var(--ds-color-accent-border-strong);
     --ds-color-text-subtle: var(--ds-color-accent-text-subtle);
-    --ds-color-icon-subtle: var(--ds-color-accent-text-subtle);
+    --ds-color-icon-subtle: var(--ds-color-accent-icon-subtle);
     --ds-color-text-default: var(--ds-color-accent-text-default);
     --ds-color-base-default: var(--ds-color-accent-base-default);
     --ds-color-base-hover: var(--ds-color-accent-base-hover);
@@ -1050,7 +1050,7 @@ build: v1.12.1
     --ds-color-border-default: var(--ds-color-support1-border-default);
     --ds-color-border-strong: var(--ds-color-support1-border-strong);
     --ds-color-text-subtle: var(--ds-color-support1-text-subtle);
-    --ds-color-icon-subtle: var(--ds-color-support1-text-subtle);
+    --ds-color-icon-subtle: var(--ds-color-support1-icon-subtle);
     --ds-color-text-default: var(--ds-color-support1-text-default);
     --ds-color-base-default: var(--ds-color-support1-base-default);
     --ds-color-base-hover: var(--ds-color-support1-base-hover);

--- a/packages/themes/src/themes/tilskudd.css
+++ b/packages/themes/src/themes/tilskudd.css
@@ -1,6 +1,7 @@
 @charset "UTF-8";
 /*
 build: v1.12.1
+design-tokens: v1.12.1
 */
 
 @layer ds.theme.size-mode {
@@ -128,7 +129,6 @@ build: v1.12.1
     --ds-color-accent-border-default: #a2afb8;
     --ds-color-accent-border-strong: #10171f;
     --ds-color-accent-text-subtle: #53595e;
-    --ds-color-accent-icon-subtle: #53595e;
     --ds-color-accent-text-default: #10171f;
     --ds-color-accent-base-default: #31373d;
     --ds-color-accent-base-hover: #1c242e;
@@ -145,7 +145,6 @@ build: v1.12.1
     --ds-color-neutral-border-default: #96a396;
     --ds-color-neutral-border-strong: #172915;
     --ds-color-neutral-text-subtle: #495749;
-    --ds-color-neutral-icon-subtle: #495749;
     --ds-color-neutral-text-default: #10171f;
     --ds-color-neutral-base-default: #4d524d;
     --ds-color-neutral-base-hover: #2b2e2b;
@@ -162,7 +161,6 @@ build: v1.12.1
     --ds-color-support1-border-default: #797979;
     --ds-color-support1-border-strong: #5d5d5d;
     --ds-color-support1-text-subtle: #5d5d5d;
-    --ds-color-support1-icon-subtle: #5d5d5d;
     --ds-color-support1-text-default: #2b2b2b;
     --ds-color-support1-base-default: #ffffff;
     --ds-color-support1-base-hover: #e8e8e8;
@@ -179,7 +177,6 @@ build: v1.12.1
     --ds-color-info-border-default: #a583cc;
     --ds-color-info-border-strong: #1e1529;
     --ds-color-info-text-subtle: #6b4399;
-    --ds-color-info-icon-subtle: #6b4399;
     --ds-color-info-text-default: #10171f;
     --ds-color-info-base-default: #7529cc;
     --ds-color-info-base-hover: #28163d;
@@ -196,7 +193,6 @@ build: v1.12.1
     --ds-color-success-border-default: #7bb893;
     --ds-color-success-border-strong: #132419;
     --ds-color-success-text-subtle: #187a40;
-    --ds-color-success-icon-subtle: #187a40;
     --ds-color-success-text-default: #10171f;
     --ds-color-success-base-default: #00cc52;
     --ds-color-success-base-hover: #142e1e;
@@ -213,7 +209,6 @@ build: v1.12.1
     --ds-color-warning-border-default: #f5c814;
     --ds-color-warning-border-strong: #292515;
     --ds-color-warning-text-subtle: #7a6a27;
-    --ds-color-warning-icon-subtle: #7a6a27;
     --ds-color-warning-text-default: #10171f;
     --ds-color-warning-base-default: #ffcc00;
     --ds-color-warning-base-hover: #382e04;
@@ -230,7 +225,6 @@ build: v1.12.1
     --ds-color-danger-border-default: #e58198;
     --ds-color-danger-border-strong: #261418;
     --ds-color-danger-text-subtle: #b8002b;
-    --ds-color-danger-icon-subtle: #b8002b;
     --ds-color-danger-text-default: #10171f;
     --ds-color-danger-base-default: #ff2457;
     --ds-color-danger-base-hover: #3d161f;
@@ -256,7 +250,6 @@ build: v1.12.1
       --ds-color-accent-border-default: #a2afb8;
       --ds-color-accent-border-strong: #10171f;
       --ds-color-accent-text-subtle: #53595e;
-      --ds-color-accent-icon-subtle: #53595e;
       --ds-color-accent-text-default: #10171f;
       --ds-color-accent-base-default: #31373d;
       --ds-color-accent-base-hover: #1c242e;
@@ -273,7 +266,6 @@ build: v1.12.1
       --ds-color-neutral-border-default: #96a396;
       --ds-color-neutral-border-strong: #172915;
       --ds-color-neutral-text-subtle: #495749;
-      --ds-color-neutral-icon-subtle: #495749;
       --ds-color-neutral-text-default: #10171f;
       --ds-color-neutral-base-default: #4d524d;
       --ds-color-neutral-base-hover: #2b2e2b;
@@ -290,7 +282,6 @@ build: v1.12.1
       --ds-color-support1-border-default: #797979;
       --ds-color-support1-border-strong: #5d5d5d;
       --ds-color-support1-text-subtle: #5d5d5d;
-      --ds-color-support1-icon-subtle: #5d5d5d;
       --ds-color-support1-text-default: #2b2b2b;
       --ds-color-support1-base-default: #ffffff;
       --ds-color-support1-base-hover: #e8e8e8;
@@ -307,7 +298,6 @@ build: v1.12.1
       --ds-color-info-border-default: #a583cc;
       --ds-color-info-border-strong: #1e1529;
       --ds-color-info-text-subtle: #6b4399;
-      --ds-color-info-icon-subtle: #6b4399;
       --ds-color-info-text-default: #10171f;
       --ds-color-info-base-default: #7529cc;
       --ds-color-info-base-hover: #28163d;
@@ -324,7 +314,6 @@ build: v1.12.1
       --ds-color-success-border-default: #7bb893;
       --ds-color-success-border-strong: #132419;
       --ds-color-success-text-subtle: #187a40;
-      --ds-color-success-icon-subtle: #187a40;
       --ds-color-success-text-default: #10171f;
       --ds-color-success-base-default: #00cc52;
       --ds-color-success-base-hover: #142e1e;
@@ -341,7 +330,6 @@ build: v1.12.1
       --ds-color-warning-border-default: #f5c814;
       --ds-color-warning-border-strong: #292515;
       --ds-color-warning-text-subtle: #7a6a27;
-      --ds-color-warning-icon-subtle: #7a6a27;
       --ds-color-warning-text-default: #10171f;
       --ds-color-warning-base-default: #ffcc00;
       --ds-color-warning-base-hover: #382e04;
@@ -358,7 +346,6 @@ build: v1.12.1
       --ds-color-danger-border-default: #e58198;
       --ds-color-danger-border-strong: #261418;
       --ds-color-danger-text-subtle: #b8002b;
-      --ds-color-danger-icon-subtle: #b8002b;
       --ds-color-danger-text-default: #10171f;
       --ds-color-danger-base-default: #ff2457;
       --ds-color-danger-base-hover: #3d161f;
@@ -570,7 +557,6 @@ build: v1.12.1
     --ds-color-accent-border-default: #7f8184;
     --ds-color-accent-border-strong: #a6a8aa;
     --ds-color-accent-text-subtle: #a6a8aa;
-    --ds-color-accent-icon-subtle: #a6a8aa;
     --ds-color-accent-text-default: #ececed;
     --ds-color-accent-base-default: #a9abae;
     --ds-color-accent-base-hover: #93969a;
@@ -587,7 +573,6 @@ build: v1.12.1
     --ds-color-neutral-border-default: #808280;
     --ds-color-neutral-border-strong: #a7a8a7;
     --ds-color-neutral-text-subtle: #a7a8a7;
-    --ds-color-neutral-icon-subtle: #a7a8a7;
     --ds-color-neutral-text-default: #ececec;
     --ds-color-neutral-base-default: #9ea19e;
     --ds-color-neutral-base-hover: #898c89;
@@ -604,7 +589,6 @@ build: v1.12.1
     --ds-color-support1-border-default: #818181;
     --ds-color-support1-border-strong: #a8a8a8;
     --ds-color-support1-text-subtle: #a8a8a8;
-    --ds-color-support1-icon-subtle: #a8a8a8;
     --ds-color-support1-text-default: #ececec;
     --ds-color-support1-base-default: #000000;
     --ds-color-support1-base-hover: #181818;
@@ -621,7 +605,6 @@ build: v1.12.1
     --ds-color-info-border-default: #9173c1;
     --ds-color-info-border-strong: #b39ed4;
     --ds-color-info-text-subtle: #b39ed4;
-    --ds-color-info-icon-subtle: #b39ed4;
     --ds-color-info-text-default: #efeaf6;
     --ds-color-info-base-default: #af83e2;
     --ds-color-info-base-hover: #c19fe8;
@@ -638,7 +621,6 @@ build: v1.12.1
     --ds-color-success-border-default: #469054;
     --ds-color-success-border-strong: #5bbb6d;
     --ds-color-success-text-subtle: #5bbb6d;
-    --ds-color-success-icon-subtle: #5bbb6d;
     --ds-color-success-text-default: #dcf2e0;
     --ds-color-success-base-default: #004d1f;
     --ds-color-success-base-hover: #006227;
@@ -655,7 +637,6 @@ build: v1.12.1
     --ds-color-warning-border-default: #957f43;
     --ds-color-warning-border-strong: #c1a557;
     --ds-color-warning-text-subtle: #c1a557;
-    --ds-color-warning-icon-subtle: #c1a557;
     --ds-color-warning-text-default: #faecc4;
     --ds-color-warning-base-default: #302600;
     --ds-color-warning-base-hover: #463800;
@@ -672,7 +653,6 @@ build: v1.12.1
     --ds-color-danger-border-default: #de5156;
     --ds-color-danger-border-strong: #eb8e91;
     --ds-color-danger-text-subtle: #eb8e91;
-    --ds-color-danger-icon-subtle: #eb8e91;
     --ds-color-danger-text-default: #fbe8e9;
     --ds-color-danger-base-default: #dd0034;
     --ds-color-danger-base-hover: #b7002b;
@@ -698,7 +678,6 @@ build: v1.12.1
       --ds-color-accent-border-default: #7f8184;
       --ds-color-accent-border-strong: #a6a8aa;
       --ds-color-accent-text-subtle: #a6a8aa;
-      --ds-color-accent-icon-subtle: #a6a8aa;
       --ds-color-accent-text-default: #ececed;
       --ds-color-accent-base-default: #a9abae;
       --ds-color-accent-base-hover: #93969a;
@@ -715,7 +694,6 @@ build: v1.12.1
       --ds-color-neutral-border-default: #808280;
       --ds-color-neutral-border-strong: #a7a8a7;
       --ds-color-neutral-text-subtle: #a7a8a7;
-      --ds-color-neutral-icon-subtle: #a7a8a7;
       --ds-color-neutral-text-default: #ececec;
       --ds-color-neutral-base-default: #9ea19e;
       --ds-color-neutral-base-hover: #898c89;
@@ -732,7 +710,6 @@ build: v1.12.1
       --ds-color-support1-border-default: #818181;
       --ds-color-support1-border-strong: #a8a8a8;
       --ds-color-support1-text-subtle: #a8a8a8;
-      --ds-color-support1-icon-subtle: #a8a8a8;
       --ds-color-support1-text-default: #ececec;
       --ds-color-support1-base-default: #000000;
       --ds-color-support1-base-hover: #181818;
@@ -749,7 +726,6 @@ build: v1.12.1
       --ds-color-info-border-default: #9173c1;
       --ds-color-info-border-strong: #b39ed4;
       --ds-color-info-text-subtle: #b39ed4;
-      --ds-color-info-icon-subtle: #b39ed4;
       --ds-color-info-text-default: #efeaf6;
       --ds-color-info-base-default: #af83e2;
       --ds-color-info-base-hover: #c19fe8;
@@ -766,7 +742,6 @@ build: v1.12.1
       --ds-color-success-border-default: #469054;
       --ds-color-success-border-strong: #5bbb6d;
       --ds-color-success-text-subtle: #5bbb6d;
-      --ds-color-success-icon-subtle: #5bbb6d;
       --ds-color-success-text-default: #dcf2e0;
       --ds-color-success-base-default: #004d1f;
       --ds-color-success-base-hover: #006227;
@@ -783,7 +758,6 @@ build: v1.12.1
       --ds-color-warning-border-default: #957f43;
       --ds-color-warning-border-strong: #c1a557;
       --ds-color-warning-text-subtle: #c1a557;
-      --ds-color-warning-icon-subtle: #c1a557;
       --ds-color-warning-text-default: #faecc4;
       --ds-color-warning-base-default: #302600;
       --ds-color-warning-base-hover: #463800;
@@ -800,7 +774,6 @@ build: v1.12.1
       --ds-color-danger-border-default: #de5156;
       --ds-color-danger-border-strong: #eb8e91;
       --ds-color-danger-text-subtle: #eb8e91;
-      --ds-color-danger-icon-subtle: #eb8e91;
       --ds-color-danger-text-default: #fbe8e9;
       --ds-color-danger-base-default: #dd0034;
       --ds-color-danger-base-hover: #b7002b;
@@ -917,7 +890,6 @@ build: v1.12.1
     --ds-color-border-default: var(--ds-color-accent-border-default);
     --ds-color-border-strong: var(--ds-color-accent-border-strong);
     --ds-color-text-subtle: var(--ds-color-accent-text-subtle);
-    --ds-color-icon-subtle: var(--ds-color-accent-icon-subtle);
     --ds-color-text-default: var(--ds-color-accent-text-default);
     --ds-color-base-default: var(--ds-color-accent-base-default);
     --ds-color-base-hover: var(--ds-color-accent-base-hover);
@@ -944,7 +916,6 @@ build: v1.12.1
     --ds-color-border-default: var(--ds-color-danger-border-default);
     --ds-color-border-strong: var(--ds-color-danger-border-strong);
     --ds-color-text-subtle: var(--ds-color-danger-text-subtle);
-    --ds-color-icon-subtle: var(--ds-color-danger-icon-subtle);
     --ds-color-text-default: var(--ds-color-danger-text-default);
     --ds-color-base-default: var(--ds-color-danger-base-default);
     --ds-color-base-hover: var(--ds-color-danger-base-hover);
@@ -971,7 +942,6 @@ build: v1.12.1
     --ds-color-border-default: var(--ds-color-info-border-default);
     --ds-color-border-strong: var(--ds-color-info-border-strong);
     --ds-color-text-subtle: var(--ds-color-info-text-subtle);
-    --ds-color-icon-subtle: var(--ds-color-info-icon-subtle);
     --ds-color-text-default: var(--ds-color-info-text-default);
     --ds-color-base-default: var(--ds-color-info-base-default);
     --ds-color-base-hover: var(--ds-color-info-base-hover);
@@ -996,7 +966,6 @@ build: v1.12.1
     --ds-color-border-default: var(--ds-color-neutral-border-default);
     --ds-color-border-strong: var(--ds-color-neutral-border-strong);
     --ds-color-text-subtle: var(--ds-color-neutral-text-subtle);
-    --ds-color-icon-subtle: var(--ds-color-neutral-icon-subtle);
     --ds-color-text-default: var(--ds-color-neutral-text-default);
     --ds-color-base-default: var(--ds-color-neutral-base-default);
     --ds-color-base-hover: var(--ds-color-neutral-base-hover);
@@ -1023,7 +992,6 @@ build: v1.12.1
     --ds-color-border-default: var(--ds-color-success-border-default);
     --ds-color-border-strong: var(--ds-color-success-border-strong);
     --ds-color-text-subtle: var(--ds-color-success-text-subtle);
-    --ds-color-icon-subtle: var(--ds-color-success-icon-subtle);
     --ds-color-text-default: var(--ds-color-success-text-default);
     --ds-color-base-default: var(--ds-color-success-base-default);
     --ds-color-base-hover: var(--ds-color-success-base-hover);
@@ -1050,7 +1018,6 @@ build: v1.12.1
     --ds-color-border-default: var(--ds-color-support1-border-default);
     --ds-color-border-strong: var(--ds-color-support1-border-strong);
     --ds-color-text-subtle: var(--ds-color-support1-text-subtle);
-    --ds-color-icon-subtle: var(--ds-color-support1-icon-subtle);
     --ds-color-text-default: var(--ds-color-support1-text-default);
     --ds-color-base-default: var(--ds-color-support1-base-default);
     --ds-color-base-hover: var(--ds-color-support1-base-hover);
@@ -1077,7 +1044,6 @@ build: v1.12.1
     --ds-color-border-default: var(--ds-color-warning-border-default);
     --ds-color-border-strong: var(--ds-color-warning-border-strong);
     --ds-color-text-subtle: var(--ds-color-warning-text-subtle);
-    --ds-color-icon-subtle: var(--ds-color-warning-icon-subtle);
     --ds-color-text-default: var(--ds-color-warning-text-default);
     --ds-color-base-default: var(--ds-color-warning-base-default);
     --ds-color-base-hover: var(--ds-color-warning-base-hover);

--- a/packages/themes/src/themes/tilskudd.css
+++ b/packages/themes/src/themes/tilskudd.css
@@ -1,7 +1,6 @@
 @charset "UTF-8";
 /*
 build: v1.12.1
-design-tokens: v1.12.1
 */
 
 @layer ds.theme.size-mode {
@@ -129,6 +128,7 @@ design-tokens: v1.12.1
     --ds-color-accent-border-default: #a2afb8;
     --ds-color-accent-border-strong: #10171f;
     --ds-color-accent-text-subtle: #53595e;
+    --ds-color-accent-icon-subtle: #53595e;
     --ds-color-accent-text-default: #10171f;
     --ds-color-accent-base-default: #31373d;
     --ds-color-accent-base-hover: #1c242e;
@@ -145,6 +145,7 @@ design-tokens: v1.12.1
     --ds-color-neutral-border-default: #96a396;
     --ds-color-neutral-border-strong: #172915;
     --ds-color-neutral-text-subtle: #495749;
+    --ds-color-neutral-icon-subtle: #495749;
     --ds-color-neutral-text-default: #10171f;
     --ds-color-neutral-base-default: #4d524d;
     --ds-color-neutral-base-hover: #2b2e2b;
@@ -161,6 +162,7 @@ design-tokens: v1.12.1
     --ds-color-support1-border-default: #797979;
     --ds-color-support1-border-strong: #5d5d5d;
     --ds-color-support1-text-subtle: #5d5d5d;
+    --ds-color-support1-icon-subtle: #5d5d5d;
     --ds-color-support1-text-default: #2b2b2b;
     --ds-color-support1-base-default: #ffffff;
     --ds-color-support1-base-hover: #e8e8e8;
@@ -177,6 +179,7 @@ design-tokens: v1.12.1
     --ds-color-info-border-default: #a583cc;
     --ds-color-info-border-strong: #1e1529;
     --ds-color-info-text-subtle: #6b4399;
+    --ds-color-info-icon-subtle: #6b4399;
     --ds-color-info-text-default: #10171f;
     --ds-color-info-base-default: #7529cc;
     --ds-color-info-base-hover: #28163d;
@@ -193,6 +196,7 @@ design-tokens: v1.12.1
     --ds-color-success-border-default: #7bb893;
     --ds-color-success-border-strong: #132419;
     --ds-color-success-text-subtle: #187a40;
+    --ds-color-success-icon-subtle: #187a40;
     --ds-color-success-text-default: #10171f;
     --ds-color-success-base-default: #00cc52;
     --ds-color-success-base-hover: #142e1e;
@@ -209,6 +213,7 @@ design-tokens: v1.12.1
     --ds-color-warning-border-default: #f5c814;
     --ds-color-warning-border-strong: #292515;
     --ds-color-warning-text-subtle: #7a6a27;
+    --ds-color-warning-icon-subtle: #7a6a27;
     --ds-color-warning-text-default: #10171f;
     --ds-color-warning-base-default: #ffcc00;
     --ds-color-warning-base-hover: #382e04;
@@ -225,6 +230,7 @@ design-tokens: v1.12.1
     --ds-color-danger-border-default: #e58198;
     --ds-color-danger-border-strong: #261418;
     --ds-color-danger-text-subtle: #b8002b;
+    --ds-color-danger-icon-subtle: #b8002b;
     --ds-color-danger-text-default: #10171f;
     --ds-color-danger-base-default: #ff2457;
     --ds-color-danger-base-hover: #3d161f;
@@ -250,6 +256,7 @@ design-tokens: v1.12.1
       --ds-color-accent-border-default: #a2afb8;
       --ds-color-accent-border-strong: #10171f;
       --ds-color-accent-text-subtle: #53595e;
+      --ds-color-accent-icon-subtle: #53595e;
       --ds-color-accent-text-default: #10171f;
       --ds-color-accent-base-default: #31373d;
       --ds-color-accent-base-hover: #1c242e;
@@ -266,6 +273,7 @@ design-tokens: v1.12.1
       --ds-color-neutral-border-default: #96a396;
       --ds-color-neutral-border-strong: #172915;
       --ds-color-neutral-text-subtle: #495749;
+      --ds-color-neutral-icon-subtle: #495749;
       --ds-color-neutral-text-default: #10171f;
       --ds-color-neutral-base-default: #4d524d;
       --ds-color-neutral-base-hover: #2b2e2b;
@@ -282,6 +290,7 @@ design-tokens: v1.12.1
       --ds-color-support1-border-default: #797979;
       --ds-color-support1-border-strong: #5d5d5d;
       --ds-color-support1-text-subtle: #5d5d5d;
+      --ds-color-support1-icon-subtle: #5d5d5d;
       --ds-color-support1-text-default: #2b2b2b;
       --ds-color-support1-base-default: #ffffff;
       --ds-color-support1-base-hover: #e8e8e8;
@@ -298,6 +307,7 @@ design-tokens: v1.12.1
       --ds-color-info-border-default: #a583cc;
       --ds-color-info-border-strong: #1e1529;
       --ds-color-info-text-subtle: #6b4399;
+      --ds-color-info-icon-subtle: #6b4399;
       --ds-color-info-text-default: #10171f;
       --ds-color-info-base-default: #7529cc;
       --ds-color-info-base-hover: #28163d;
@@ -314,6 +324,7 @@ design-tokens: v1.12.1
       --ds-color-success-border-default: #7bb893;
       --ds-color-success-border-strong: #132419;
       --ds-color-success-text-subtle: #187a40;
+      --ds-color-success-icon-subtle: #187a40;
       --ds-color-success-text-default: #10171f;
       --ds-color-success-base-default: #00cc52;
       --ds-color-success-base-hover: #142e1e;
@@ -330,6 +341,7 @@ design-tokens: v1.12.1
       --ds-color-warning-border-default: #f5c814;
       --ds-color-warning-border-strong: #292515;
       --ds-color-warning-text-subtle: #7a6a27;
+      --ds-color-warning-icon-subtle: #7a6a27;
       --ds-color-warning-text-default: #10171f;
       --ds-color-warning-base-default: #ffcc00;
       --ds-color-warning-base-hover: #382e04;
@@ -346,6 +358,7 @@ design-tokens: v1.12.1
       --ds-color-danger-border-default: #e58198;
       --ds-color-danger-border-strong: #261418;
       --ds-color-danger-text-subtle: #b8002b;
+      --ds-color-danger-icon-subtle: #b8002b;
       --ds-color-danger-text-default: #10171f;
       --ds-color-danger-base-default: #ff2457;
       --ds-color-danger-base-hover: #3d161f;
@@ -557,6 +570,7 @@ design-tokens: v1.12.1
     --ds-color-accent-border-default: #7f8184;
     --ds-color-accent-border-strong: #a6a8aa;
     --ds-color-accent-text-subtle: #a6a8aa;
+    --ds-color-accent-icon-subtle: #a6a8aa;
     --ds-color-accent-text-default: #ececed;
     --ds-color-accent-base-default: #a9abae;
     --ds-color-accent-base-hover: #93969a;
@@ -573,6 +587,7 @@ design-tokens: v1.12.1
     --ds-color-neutral-border-default: #808280;
     --ds-color-neutral-border-strong: #a7a8a7;
     --ds-color-neutral-text-subtle: #a7a8a7;
+    --ds-color-neutral-icon-subtle: #a7a8a7;
     --ds-color-neutral-text-default: #ececec;
     --ds-color-neutral-base-default: #9ea19e;
     --ds-color-neutral-base-hover: #898c89;
@@ -589,6 +604,7 @@ design-tokens: v1.12.1
     --ds-color-support1-border-default: #818181;
     --ds-color-support1-border-strong: #a8a8a8;
     --ds-color-support1-text-subtle: #a8a8a8;
+    --ds-color-support1-icon-subtle: #a8a8a8;
     --ds-color-support1-text-default: #ececec;
     --ds-color-support1-base-default: #000000;
     --ds-color-support1-base-hover: #181818;
@@ -605,6 +621,7 @@ design-tokens: v1.12.1
     --ds-color-info-border-default: #9173c1;
     --ds-color-info-border-strong: #b39ed4;
     --ds-color-info-text-subtle: #b39ed4;
+    --ds-color-info-icon-subtle: #b39ed4;
     --ds-color-info-text-default: #efeaf6;
     --ds-color-info-base-default: #af83e2;
     --ds-color-info-base-hover: #c19fe8;
@@ -621,6 +638,7 @@ design-tokens: v1.12.1
     --ds-color-success-border-default: #469054;
     --ds-color-success-border-strong: #5bbb6d;
     --ds-color-success-text-subtle: #5bbb6d;
+    --ds-color-success-icon-subtle: #5bbb6d;
     --ds-color-success-text-default: #dcf2e0;
     --ds-color-success-base-default: #004d1f;
     --ds-color-success-base-hover: #006227;
@@ -637,6 +655,7 @@ design-tokens: v1.12.1
     --ds-color-warning-border-default: #957f43;
     --ds-color-warning-border-strong: #c1a557;
     --ds-color-warning-text-subtle: #c1a557;
+    --ds-color-warning-icon-subtle: #c1a557;
     --ds-color-warning-text-default: #faecc4;
     --ds-color-warning-base-default: #302600;
     --ds-color-warning-base-hover: #463800;
@@ -653,6 +672,7 @@ design-tokens: v1.12.1
     --ds-color-danger-border-default: #de5156;
     --ds-color-danger-border-strong: #eb8e91;
     --ds-color-danger-text-subtle: #eb8e91;
+    --ds-color-danger-icon-subtle: #eb8e91;
     --ds-color-danger-text-default: #fbe8e9;
     --ds-color-danger-base-default: #dd0034;
     --ds-color-danger-base-hover: #b7002b;
@@ -678,6 +698,7 @@ design-tokens: v1.12.1
       --ds-color-accent-border-default: #7f8184;
       --ds-color-accent-border-strong: #a6a8aa;
       --ds-color-accent-text-subtle: #a6a8aa;
+      --ds-color-accent-icon-subtle: #a6a8aa;
       --ds-color-accent-text-default: #ececed;
       --ds-color-accent-base-default: #a9abae;
       --ds-color-accent-base-hover: #93969a;
@@ -694,6 +715,7 @@ design-tokens: v1.12.1
       --ds-color-neutral-border-default: #808280;
       --ds-color-neutral-border-strong: #a7a8a7;
       --ds-color-neutral-text-subtle: #a7a8a7;
+      --ds-color-neutral-icon-subtle: #a7a8a7;
       --ds-color-neutral-text-default: #ececec;
       --ds-color-neutral-base-default: #9ea19e;
       --ds-color-neutral-base-hover: #898c89;
@@ -710,6 +732,7 @@ design-tokens: v1.12.1
       --ds-color-support1-border-default: #818181;
       --ds-color-support1-border-strong: #a8a8a8;
       --ds-color-support1-text-subtle: #a8a8a8;
+      --ds-color-support1-icon-subtle: #a8a8a8;
       --ds-color-support1-text-default: #ececec;
       --ds-color-support1-base-default: #000000;
       --ds-color-support1-base-hover: #181818;
@@ -726,6 +749,7 @@ design-tokens: v1.12.1
       --ds-color-info-border-default: #9173c1;
       --ds-color-info-border-strong: #b39ed4;
       --ds-color-info-text-subtle: #b39ed4;
+      --ds-color-info-icon-subtle: #b39ed4;
       --ds-color-info-text-default: #efeaf6;
       --ds-color-info-base-default: #af83e2;
       --ds-color-info-base-hover: #c19fe8;
@@ -742,6 +766,7 @@ design-tokens: v1.12.1
       --ds-color-success-border-default: #469054;
       --ds-color-success-border-strong: #5bbb6d;
       --ds-color-success-text-subtle: #5bbb6d;
+      --ds-color-success-icon-subtle: #5bbb6d;
       --ds-color-success-text-default: #dcf2e0;
       --ds-color-success-base-default: #004d1f;
       --ds-color-success-base-hover: #006227;
@@ -758,6 +783,7 @@ design-tokens: v1.12.1
       --ds-color-warning-border-default: #957f43;
       --ds-color-warning-border-strong: #c1a557;
       --ds-color-warning-text-subtle: #c1a557;
+      --ds-color-warning-icon-subtle: #c1a557;
       --ds-color-warning-text-default: #faecc4;
       --ds-color-warning-base-default: #302600;
       --ds-color-warning-base-hover: #463800;
@@ -774,6 +800,7 @@ design-tokens: v1.12.1
       --ds-color-danger-border-default: #de5156;
       --ds-color-danger-border-strong: #eb8e91;
       --ds-color-danger-text-subtle: #eb8e91;
+      --ds-color-danger-icon-subtle: #eb8e91;
       --ds-color-danger-text-default: #fbe8e9;
       --ds-color-danger-base-default: #dd0034;
       --ds-color-danger-base-hover: #b7002b;
@@ -890,6 +917,7 @@ design-tokens: v1.12.1
     --ds-color-border-default: var(--ds-color-accent-border-default);
     --ds-color-border-strong: var(--ds-color-accent-border-strong);
     --ds-color-text-subtle: var(--ds-color-accent-text-subtle);
+    --ds-color-icon-subtle: var(--ds-color-accent-text-subtle);
     --ds-color-text-default: var(--ds-color-accent-text-default);
     --ds-color-base-default: var(--ds-color-accent-base-default);
     --ds-color-base-hover: var(--ds-color-accent-base-hover);
@@ -916,6 +944,7 @@ design-tokens: v1.12.1
     --ds-color-border-default: var(--ds-color-danger-border-default);
     --ds-color-border-strong: var(--ds-color-danger-border-strong);
     --ds-color-text-subtle: var(--ds-color-danger-text-subtle);
+    --ds-color-icon-subtle: var(--ds-color-danger-icon-subtle);
     --ds-color-text-default: var(--ds-color-danger-text-default);
     --ds-color-base-default: var(--ds-color-danger-base-default);
     --ds-color-base-hover: var(--ds-color-danger-base-hover);
@@ -942,6 +971,7 @@ design-tokens: v1.12.1
     --ds-color-border-default: var(--ds-color-info-border-default);
     --ds-color-border-strong: var(--ds-color-info-border-strong);
     --ds-color-text-subtle: var(--ds-color-info-text-subtle);
+    --ds-color-icon-subtle: var(--ds-color-info-icon-subtle);
     --ds-color-text-default: var(--ds-color-info-text-default);
     --ds-color-base-default: var(--ds-color-info-base-default);
     --ds-color-base-hover: var(--ds-color-info-base-hover);
@@ -966,6 +996,7 @@ design-tokens: v1.12.1
     --ds-color-border-default: var(--ds-color-neutral-border-default);
     --ds-color-border-strong: var(--ds-color-neutral-border-strong);
     --ds-color-text-subtle: var(--ds-color-neutral-text-subtle);
+    --ds-color-icon-subtle: var(--ds-color-neutral-icon-subtle);
     --ds-color-text-default: var(--ds-color-neutral-text-default);
     --ds-color-base-default: var(--ds-color-neutral-base-default);
     --ds-color-base-hover: var(--ds-color-neutral-base-hover);
@@ -992,6 +1023,7 @@ design-tokens: v1.12.1
     --ds-color-border-default: var(--ds-color-success-border-default);
     --ds-color-border-strong: var(--ds-color-success-border-strong);
     --ds-color-text-subtle: var(--ds-color-success-text-subtle);
+    --ds-color-icon-subtle: var(--ds-color-success-icon-subtle);
     --ds-color-text-default: var(--ds-color-success-text-default);
     --ds-color-base-default: var(--ds-color-success-base-default);
     --ds-color-base-hover: var(--ds-color-success-base-hover);
@@ -1018,6 +1050,7 @@ design-tokens: v1.12.1
     --ds-color-border-default: var(--ds-color-support1-border-default);
     --ds-color-border-strong: var(--ds-color-support1-border-strong);
     --ds-color-text-subtle: var(--ds-color-support1-text-subtle);
+    --ds-color-icon-subtle: var(--ds-color-support1-text-subtle);
     --ds-color-text-default: var(--ds-color-support1-text-default);
     --ds-color-base-default: var(--ds-color-support1-base-default);
     --ds-color-base-hover: var(--ds-color-support1-base-hover);
@@ -1044,6 +1077,7 @@ design-tokens: v1.12.1
     --ds-color-border-default: var(--ds-color-warning-border-default);
     --ds-color-border-strong: var(--ds-color-warning-border-strong);
     --ds-color-text-subtle: var(--ds-color-warning-text-subtle);
+    --ds-color-icon-subtle: var(--ds-color-warning-icon-subtle);
     --ds-color-text-default: var(--ds-color-warning-text-default);
     --ds-color-base-default: var(--ds-color-warning-base-default);
     --ds-color-base-hover: var(--ds-color-warning-base-hover);

--- a/packages/themes/src/themes/tilskudd.tailwind.css
+++ b/packages/themes/src/themes/tilskudd.tailwind.css
@@ -18,6 +18,7 @@
   --color-accent-border-default: var(--ds-color-accent-border-default);
   --color-accent-border-strong: var(--ds-color-accent-border-strong);
   --color-accent-border-subtle: var(--ds-color-accent-border-subtle);
+  --color-accent-icon-subtle: var(--ds-color-accent-icon-subtle);
   --color-accent-surface-active: var(--ds-color-accent-surface-active);
   --color-accent-surface-default: var(--ds-color-accent-surface-default);
   --color-accent-surface-hover: var(--ds-color-accent-surface-hover);
@@ -48,12 +49,14 @@
   --color-danger-border-default: var(--ds-color-danger-border-default);
   --color-danger-border-strong: var(--ds-color-danger-border-strong);
   --color-danger-border-subtle: var(--ds-color-danger-border-subtle);
+  --color-danger-icon-subtle: var(--ds-color-danger-icon-subtle);
   --color-danger-surface-active: var(--ds-color-danger-surface-active);
   --color-danger-surface-default: var(--ds-color-danger-surface-default);
   --color-danger-surface-hover: var(--ds-color-danger-surface-hover);
   --color-danger-surface-tinted: var(--ds-color-danger-surface-tinted);
   --color-danger-text-default: var(--ds-color-danger-text-default);
   --color-danger-text-subtle: var(--ds-color-danger-text-subtle);
+  --color-icon-subtle: var(--ds-color-icon-subtle);
   --color-info-background-default: var(--ds-color-info-background-default);
   --color-info-background-tinted: var(--ds-color-info-background-tinted);
   --color-info-base-active: var(--ds-color-info-base-active);
@@ -66,6 +69,7 @@
   --color-info-border-default: var(--ds-color-info-border-default);
   --color-info-border-strong: var(--ds-color-info-border-strong);
   --color-info-border-subtle: var(--ds-color-info-border-subtle);
+  --color-info-icon-subtle: var(--ds-color-info-icon-subtle);
   --color-info-surface-active: var(--ds-color-info-surface-active);
   --color-info-surface-default: var(--ds-color-info-surface-default);
   --color-info-surface-hover: var(--ds-color-info-surface-hover);
@@ -88,6 +92,7 @@
   --color-neutral-border-default: var(--ds-color-neutral-border-default);
   --color-neutral-border-strong: var(--ds-color-neutral-border-strong);
   --color-neutral-border-subtle: var(--ds-color-neutral-border-subtle);
+  --color-neutral-icon-subtle: var(--ds-color-neutral-icon-subtle);
   --color-neutral-surface-active: var(--ds-color-neutral-surface-active);
   --color-neutral-surface-default: var(--ds-color-neutral-surface-default);
   --color-neutral-surface-hover: var(--ds-color-neutral-surface-hover);
@@ -110,6 +115,7 @@
   --color-success-border-default: var(--ds-color-success-border-default);
   --color-success-border-strong: var(--ds-color-success-border-strong);
   --color-success-border-subtle: var(--ds-color-success-border-subtle);
+  --color-success-icon-subtle: var(--ds-color-success-icon-subtle);
   --color-success-surface-active: var(--ds-color-success-surface-active);
   --color-success-surface-default: var(--ds-color-success-surface-default);
   --color-success-surface-hover: var(--ds-color-success-surface-hover);
@@ -134,6 +140,7 @@
   --color-support1-border-default: var(--ds-color-support1-border-default);
   --color-support1-border-strong: var(--ds-color-support1-border-strong);
   --color-support1-border-subtle: var(--ds-color-support1-border-subtle);
+  --color-support1-icon-subtle: var(--ds-color-support1-icon-subtle);
   --color-support1-surface-active: var(--ds-color-support1-surface-active);
   --color-support1-surface-default: var(--ds-color-support1-surface-default);
   --color-support1-surface-hover: var(--ds-color-support1-surface-hover);
@@ -162,6 +169,7 @@
   --color-warning-border-default: var(--ds-color-warning-border-default);
   --color-warning-border-strong: var(--ds-color-warning-border-strong);
   --color-warning-border-subtle: var(--ds-color-warning-border-subtle);
+  --color-warning-icon-subtle: var(--ds-color-warning-icon-subtle);
   --color-warning-surface-active: var(--ds-color-warning-surface-active);
   --color-warning-surface-default: var(--ds-color-warning-surface-default);
   --color-warning-surface-hover: var(--ds-color-warning-surface-hover);

--- a/packages/themes/src/themes/tilskudd.tailwind.css
+++ b/packages/themes/src/themes/tilskudd.tailwind.css
@@ -18,7 +18,6 @@
   --color-accent-border-default: var(--ds-color-accent-border-default);
   --color-accent-border-strong: var(--ds-color-accent-border-strong);
   --color-accent-border-subtle: var(--ds-color-accent-border-subtle);
-  --color-accent-icon-subtle: var(--ds-color-accent-icon-subtle);
   --color-accent-surface-active: var(--ds-color-accent-surface-active);
   --color-accent-surface-default: var(--ds-color-accent-surface-default);
   --color-accent-surface-hover: var(--ds-color-accent-surface-hover);
@@ -49,14 +48,12 @@
   --color-danger-border-default: var(--ds-color-danger-border-default);
   --color-danger-border-strong: var(--ds-color-danger-border-strong);
   --color-danger-border-subtle: var(--ds-color-danger-border-subtle);
-  --color-danger-icon-subtle: var(--ds-color-danger-icon-subtle);
   --color-danger-surface-active: var(--ds-color-danger-surface-active);
   --color-danger-surface-default: var(--ds-color-danger-surface-default);
   --color-danger-surface-hover: var(--ds-color-danger-surface-hover);
   --color-danger-surface-tinted: var(--ds-color-danger-surface-tinted);
   --color-danger-text-default: var(--ds-color-danger-text-default);
   --color-danger-text-subtle: var(--ds-color-danger-text-subtle);
-  --color-icon-subtle: var(--ds-color-icon-subtle);
   --color-info-background-default: var(--ds-color-info-background-default);
   --color-info-background-tinted: var(--ds-color-info-background-tinted);
   --color-info-base-active: var(--ds-color-info-base-active);
@@ -69,7 +66,6 @@
   --color-info-border-default: var(--ds-color-info-border-default);
   --color-info-border-strong: var(--ds-color-info-border-strong);
   --color-info-border-subtle: var(--ds-color-info-border-subtle);
-  --color-info-icon-subtle: var(--ds-color-info-icon-subtle);
   --color-info-surface-active: var(--ds-color-info-surface-active);
   --color-info-surface-default: var(--ds-color-info-surface-default);
   --color-info-surface-hover: var(--ds-color-info-surface-hover);
@@ -92,7 +88,6 @@
   --color-neutral-border-default: var(--ds-color-neutral-border-default);
   --color-neutral-border-strong: var(--ds-color-neutral-border-strong);
   --color-neutral-border-subtle: var(--ds-color-neutral-border-subtle);
-  --color-neutral-icon-subtle: var(--ds-color-neutral-icon-subtle);
   --color-neutral-surface-active: var(--ds-color-neutral-surface-active);
   --color-neutral-surface-default: var(--ds-color-neutral-surface-default);
   --color-neutral-surface-hover: var(--ds-color-neutral-surface-hover);
@@ -115,7 +110,6 @@
   --color-success-border-default: var(--ds-color-success-border-default);
   --color-success-border-strong: var(--ds-color-success-border-strong);
   --color-success-border-subtle: var(--ds-color-success-border-subtle);
-  --color-success-icon-subtle: var(--ds-color-success-icon-subtle);
   --color-success-surface-active: var(--ds-color-success-surface-active);
   --color-success-surface-default: var(--ds-color-success-surface-default);
   --color-success-surface-hover: var(--ds-color-success-surface-hover);
@@ -140,7 +134,6 @@
   --color-support1-border-default: var(--ds-color-support1-border-default);
   --color-support1-border-strong: var(--ds-color-support1-border-strong);
   --color-support1-border-subtle: var(--ds-color-support1-border-subtle);
-  --color-support1-icon-subtle: var(--ds-color-support1-icon-subtle);
   --color-support1-surface-active: var(--ds-color-support1-surface-active);
   --color-support1-surface-default: var(--ds-color-support1-surface-default);
   --color-support1-surface-hover: var(--ds-color-support1-surface-hover);
@@ -169,7 +162,6 @@
   --color-warning-border-default: var(--ds-color-warning-border-default);
   --color-warning-border-strong: var(--ds-color-warning-border-strong);
   --color-warning-border-subtle: var(--ds-color-warning-border-subtle);
-  --color-warning-icon-subtle: var(--ds-color-warning-icon-subtle);
   --color-warning-surface-active: var(--ds-color-warning-surface-active);
   --color-warning-surface-default: var(--ds-color-warning-surface-default);
   --color-warning-surface-hover: var(--ds-color-warning-surface-hover);
@@ -211,6 +203,7 @@
   --color-border-default: var(--ds-color-border-default);
   --color-border-strong: var(--ds-color-border-strong);
   --color-text-subtle: var(--ds-color-text-subtle);
+  --color-icon-subtle: var(--ds-color-icon-subtle);
   --color-text-default: var(--ds-color-text-default);
   --color-base-default: var(--ds-color-base-default);
   --color-base-hover: var(--ds-color-base-hover);

--- a/packages/themes/src/themes/types.d.ts
+++ b/packages/themes/src/themes/types.d.ts
@@ -1,17 +1,16 @@
 /* build: v1.12.1 */
 import type {} from '@digdir/designsystemet-types'
+export type { Size } from '@digdir/designsystemet-types'
 
 // Augment types based on theme
-declare module '@digdir/designsystemet-types' {
-  export interface ColorDefinitions {
-    accent: never
-    support1: never
-    neutral: never
-  }
-  export interface SeverityColorDefinitions {
-    info: never
-    success: never
-    warning: never
-    danger: never
-  }
+export interface ColorDefinitions {
+  accent: never
+  support1: never
+  neutral: never
+}
+export interface SeverityColorDefinitions {
+  info: never
+  success: never
+  warning: never
+  danger: never
 }

--- a/packages/themes/src/themes/types.d.ts
+++ b/packages/themes/src/themes/types.d.ts
@@ -1,16 +1,17 @@
 /* build: v1.12.1 */
 import type {} from '@digdir/designsystemet-types'
-export type { Size } from '@digdir/designsystemet-types'
 
 // Augment types based on theme
-export interface ColorDefinitions {
-  accent: never
-  support1: never
-  neutral: never
-}
-export interface SeverityColorDefinitions {
-  info: never
-  success: never
-  warning: never
-  danger: never
+declare module '@digdir/designsystemet-types' {
+  export interface ColorDefinitions {
+    accent: never
+    support1: never
+    neutral: never
+  }
+  export interface SeverityColorDefinitions {
+    info: never
+    success: never
+    warning: never
+    danger: never
+  }
 }

--- a/tools/apply-custom-tokens.mjs
+++ b/tools/apply-custom-tokens.mjs
@@ -8,6 +8,7 @@ const __dirname = dirname(fileURLToPath(import.meta.url))
 const repoRoot = resolve(__dirname, '..')
 const semanticTokensDir = join(repoRoot, 'design-tokens', 'semantic')
 const themesDir = join(repoRoot, 'packages', 'themes', 'src', 'themes')
+const mode = process.argv[2] ?? 'all'
 
 const aliasMap = {
   'text-subtle': ['icon-subtle'],
@@ -143,6 +144,78 @@ const collectTailwindFiles = async (directory) => {
   }
 }
 
+const collectThemeCssFiles = async (directory) => {
+  try {
+    const entries = await readdir(directory, { withFileTypes: true })
+
+    return entries
+      .filter(
+        (entry) =>
+          entry.isFile() &&
+          entry.name.endsWith('.css') &&
+          !entry.name.endsWith('.tailwind.css'),
+      )
+      .map((entry) => join(directory, entry.name))
+  } catch (error) {
+    if (error && typeof error === 'object' && error.code === 'ENOENT') {
+      return []
+    }
+
+    throw error
+  }
+}
+
+const applyThemeAliases = (content) => {
+  const lines = content.split('\n')
+  const nextLines = []
+  let changed = false
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index]
+    nextLines.push(line)
+
+    for (const [sourceKey, aliasKeys] of Object.entries(aliasMap)) {
+      const sourceLineMatch = line.match(
+        new RegExp(
+          `^(\\s*)--ds-color-${sourceKey}: var\\(--ds-color-([a-z0-9-]+)-${sourceKey}\\);$`,
+        ),
+      )
+
+      if (!sourceLineMatch) {
+        continue
+      }
+
+      const [, indentation, colorName] = sourceLineMatch
+      const blockEndIndex = lines
+        .slice(index + 1)
+        .findIndex((candidate) => candidate.trim() === '}')
+
+      if (blockEndIndex === -1) {
+        continue
+      }
+
+      const blockLines = lines.slice(index + 1, index + 1 + blockEndIndex)
+
+      for (const aliasKey of aliasKeys) {
+        const aliasLine = `${indentation}--ds-color-${aliasKey}: var(--ds-color-${colorName}-${aliasKey});`
+
+        if (blockLines.includes(aliasLine)) {
+          continue
+        }
+
+        nextLines.push(aliasLine)
+        changed = true
+      }
+    }
+  }
+
+  if (!changed) {
+    return { changed: false, content }
+  }
+
+  return { changed: true, content: nextLines.join('\n') }
+}
+
 const applyTailwindAliases = (content) => {
   const lines = content.split('\n')
   const startIndex = lines.findIndex((line) => line.trim() === '[data-color] {')
@@ -205,51 +278,91 @@ const applyTailwindAliases = (content) => {
   }
 }
 
-const jsonFiles = await collectJsonFiles(semanticTokensDir)
-let updatedFiles = 0
-let createdAliases = 0
+const applyTokenAliases = async () => {
+  const jsonFiles = await collectJsonFiles(semanticTokensDir)
+  let updatedFiles = 0
+  let createdAliases = 0
 
-for (const filePath of jsonFiles) {
-  const raw = await readFile(filePath, 'utf8')
-  const document = JSON.parse(raw)
-  const changes = applyAliases(document)
+  for (const filePath of jsonFiles) {
+    const raw = await readFile(filePath, 'utf8')
+    const document = JSON.parse(raw)
+    const changes = applyAliases(document)
 
-  if (changes === 0) {
-    continue
+    if (changes === 0) {
+      continue
+    }
+
+    await writeFile(filePath, `${JSON.stringify(document, null, 2)}\n`)
+    updatedFiles += 1
+    createdAliases += changes
+    console.log(`Updated ${filePath} (${changes} aliases)`)
   }
 
-  await writeFile(filePath, `${JSON.stringify(document, null, 2)}\n`)
-  updatedFiles += 1
-  createdAliases += changes
-  console.log(`Updated ${filePath} (${changes} aliases)`)
-}
+  if (updatedFiles === 0) {
+    console.log('No custom token aliases were added.')
+    return
+  }
 
-if (updatedFiles === 0) {
-  console.log('No custom token aliases were added.')
-} else {
   console.log(
     `Added ${createdAliases} custom token aliases across ${updatedFiles} files.`,
   )
 }
 
-const tailwindFiles = await collectTailwindFiles(themesDir)
-let updatedTailwindFiles = 0
+const patchBuildOutputs = async () => {
+  const tailwindFiles = await collectTailwindFiles(themesDir)
+  let updatedTailwindFiles = 0
 
-for (const filePath of tailwindFiles) {
-  const raw = await readFile(filePath, 'utf8')
-  const { changed, content } = applyTailwindAliases(raw)
+  for (const filePath of tailwindFiles) {
+    const raw = await readFile(filePath, 'utf8')
+    const { changed, content } = applyTailwindAliases(raw)
 
-  if (!changed) {
-    continue
+    if (!changed) {
+      continue
+    }
+
+    await writeFile(filePath, content)
+    updatedTailwindFiles += 1
+    console.log(`Patched Tailwind aliases in ${filePath}`)
   }
 
-  await writeFile(filePath, content)
-  updatedTailwindFiles += 1
-  console.log(`Patched Tailwind aliases in ${filePath}`)
+  if (updatedTailwindFiles === 0) {
+    console.log('No Tailwind alias patches were needed.')
+  } else {
+    console.log(`Patched Tailwind aliases in ${updatedTailwindFiles} files.`)
+  }
+
+  const themeCssFiles = await collectThemeCssFiles(themesDir)
+  let updatedThemeCssFiles = 0
+
+  for (const filePath of themeCssFiles) {
+    const raw = await readFile(filePath, 'utf8')
+    const { changed, content } = applyThemeAliases(raw)
+
+    if (!changed) {
+      continue
+    }
+
+    await writeFile(filePath, content)
+    updatedThemeCssFiles += 1
+    console.log(`Patched theme aliases in ${filePath}`)
+  }
+
+  if (updatedThemeCssFiles === 0) {
+    console.log('No theme alias patches were needed.')
+    return
+  }
+
+  console.log(`Patched theme aliases in ${updatedThemeCssFiles} files.`)
 }
 
-if (updatedTailwindFiles === 0) {
-  console.log('No Tailwind alias patches were needed.')
-} else {
-  console.log(`Patched Tailwind aliases in ${updatedTailwindFiles} files.`)
+if (!['all', 'tokens', 'outputs'].includes(mode)) {
+  throw new Error(`Unsupported mode: ${mode}`)
+}
+
+if (mode === 'all' || mode === 'tokens') {
+  await applyTokenAliases()
+}
+
+if (mode === 'all' || mode === 'outputs') {
+  await patchBuildOutputs()
 }

--- a/tools/apply-custom-tokens.mjs
+++ b/tools/apply-custom-tokens.mjs
@@ -7,6 +7,7 @@ import { fileURLToPath } from 'node:url'
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const repoRoot = resolve(__dirname, '..')
 const semanticTokensDir = join(repoRoot, 'design-tokens', 'semantic')
+const themesDir = join(repoRoot, 'packages', 'themes', 'src', 'themes')
 
 const aliasMap = {
   'text-subtle': ['icon-subtle'],
@@ -126,6 +127,84 @@ const collectJsonFiles = async (directory) => {
   return files.flat()
 }
 
+const collectTailwindFiles = async (directory) => {
+  try {
+    const entries = await readdir(directory, { withFileTypes: true })
+
+    return entries
+      .filter((entry) => entry.isFile() && entry.name.endsWith('.tailwind.css'))
+      .map((entry) => join(directory, entry.name))
+  } catch (error) {
+    if (error && typeof error === 'object' && error.code === 'ENOENT') {
+      return []
+    }
+
+    throw error
+  }
+}
+
+const applyTailwindAliases = (content) => {
+  const lines = content.split('\n')
+  const startIndex = lines.findIndex((line) => line.trim() === '[data-color] {')
+
+  if (startIndex === -1) {
+    return { changed: false, content }
+  }
+
+  let endIndex = startIndex + 1
+
+  while (endIndex < lines.length && lines[endIndex].trim() !== '}') {
+    endIndex += 1
+  }
+
+  if (endIndex >= lines.length) {
+    return { changed: false, content }
+  }
+
+  const blockLines = lines.slice(startIndex, endIndex + 1)
+  let changed = false
+
+  for (const [sourceKey, aliasKeys] of Object.entries(aliasMap)) {
+    const sourceLinePattern = new RegExp(
+      `^(\\s*)--color-${sourceKey}: var\\(--ds-color-${sourceKey}\\);$`,
+    )
+    const sourceLineIndex = blockLines.findIndex((line) =>
+      sourceLinePattern.test(line),
+    )
+
+    if (sourceLineIndex === -1) {
+      continue
+    }
+
+    const sourceLine = blockLines[sourceLineIndex]
+    const indentation = sourceLine.match(sourceLinePattern)?.[1] ?? ''
+
+    for (const aliasKey of aliasKeys) {
+      const aliasLine = `${indentation}--color-${aliasKey}: var(--ds-color-${aliasKey});`
+
+      if (blockLines.includes(aliasLine)) {
+        continue
+      }
+
+      blockLines.splice(sourceLineIndex + 1, 0, aliasLine)
+      changed = true
+    }
+  }
+
+  if (!changed) {
+    return { changed: false, content }
+  }
+
+  return {
+    changed: true,
+    content: [
+      ...lines.slice(0, startIndex),
+      ...blockLines,
+      ...lines.slice(endIndex + 1),
+    ].join('\n'),
+  }
+}
+
 const jsonFiles = await collectJsonFiles(semanticTokensDir)
 let updatedFiles = 0
 let createdAliases = 0
@@ -151,4 +230,26 @@ if (updatedFiles === 0) {
   console.log(
     `Added ${createdAliases} custom token aliases across ${updatedFiles} files.`,
   )
+}
+
+const tailwindFiles = await collectTailwindFiles(themesDir)
+let updatedTailwindFiles = 0
+
+for (const filePath of tailwindFiles) {
+  const raw = await readFile(filePath, 'utf8')
+  const { changed, content } = applyTailwindAliases(raw)
+
+  if (!changed) {
+    continue
+  }
+
+  await writeFile(filePath, content)
+  updatedTailwindFiles += 1
+  console.log(`Patched Tailwind aliases in ${filePath}`)
+}
+
+if (updatedTailwindFiles === 0) {
+  console.log('No Tailwind alias patches were needed.')
+} else {
+  console.log(`Patched Tailwind aliases in ${updatedTailwindFiles} files.`)
 }

--- a/tools/apply-custom-tokens.mjs
+++ b/tools/apply-custom-tokens.mjs
@@ -12,6 +12,23 @@ const aliasMap = {
   'text-subtle': ['icon-subtle'],
 }
 
+const cloneTokenForAlias = (value, sourceKey, aliasKey) => {
+  const clone = JSON.parse(JSON.stringify(value))
+
+  if (typeof clone.$value === 'string') {
+    clone.$value = clone.$value.replace(
+      new RegExp(`\\.${sourceKey}(?=})`, 'g'),
+      `.${aliasKey}`,
+    )
+  }
+
+  return clone
+}
+
+const areEqual = (left, right) => {
+  return JSON.stringify(left) === JSON.stringify(right)
+}
+
 const isTokenObject = (value) => {
   return (
     typeof value === 'object' &&
@@ -20,8 +37,6 @@ const isTokenObject = (value) => {
     ('$type' in value || '$value' in value)
   )
 }
-
-const cloneToken = (value) => JSON.parse(JSON.stringify(value))
 
 const applyAliases = (value) => {
   if (Array.isArray(value)) {
@@ -45,13 +60,23 @@ const applyAliases = (value) => {
     let inserted = 0
 
     for (const aliasKey of aliasKeys) {
-      if (aliasKey in value) {
+      const nextAliasValue = cloneTokenForAlias(
+        sourceValue,
+        sourceKey,
+        aliasKey,
+      )
+
+      if (!(aliasKey in value)) {
+        inserted += 1
+        changes += 1
+        value[aliasKey] = nextAliasValue
         continue
       }
 
-      inserted += 1
-      changes += 1
-      value[aliasKey] = cloneToken(sourceValue)
+      if (!areEqual(value[aliasKey], nextAliasValue)) {
+        changes += 1
+        value[aliasKey] = nextAliasValue
+      }
     }
 
     if (inserted > 0) {

--- a/tools/apply-custom-tokens.mjs
+++ b/tools/apply-custom-tokens.mjs
@@ -28,16 +28,9 @@ const semanticTokensDir = join(repoRoot, 'design-tokens', 'semantic')
 const themesDir = join(repoRoot, 'packages', 'themes', 'src', 'themes')
 const mode = process.argv[2]
 
-const cloneTokenForAlias = (value, sourceKey, aliasKey) => {
+const cloneTokenForAlias = (value, sourcePath) => {
   const clone = JSON.parse(JSON.stringify(value))
-
-  if (typeof clone.$value === 'string') {
-    clone.$value = clone.$value.replace(
-      new RegExp(`\\.${sourceKey}(?=})`, 'g'),
-      `.${aliasKey}`,
-    )
-  }
-
+  clone.$value = `{${sourcePath}}`
   return clone
 }
 
@@ -54,9 +47,9 @@ const isTokenObject = (value) => {
   )
 }
 
-const applyAliases = (value) => {
+const applyAliases = (value, path = '') => {
   if (Array.isArray(value)) {
-    return value.reduce((count, item) => count + applyAliases(item), 0)
+    return value.reduce((count, item) => count + applyAliases(item, path), 0)
   }
 
   if (!value || typeof value !== 'object') {
@@ -72,15 +65,12 @@ const applyAliases = (value) => {
       continue
     }
 
+    const sourcePath = path ? `${path}.${sourceKey}` : sourceKey
     const snapshot = Object.entries(value)
     let inserted = 0
 
     for (const aliasKey of aliasKeys) {
-      const nextAliasValue = cloneTokenForAlias(
-        sourceValue,
-        sourceKey,
-        aliasKey,
-      )
+      const nextAliasValue = cloneTokenForAlias(sourceValue, sourcePath)
 
       if (!(aliasKey in value)) {
         inserted += 1
@@ -118,8 +108,9 @@ const applyAliases = (value) => {
     }
   }
 
-  for (const child of Object.values(value)) {
-    changes += applyAliases(child)
+  for (const [key, child] of Object.entries(value)) {
+    const childPath = path ? `${path}.${key}` : key
+    changes += applyAliases(child, childPath)
   }
 
   return changes

--- a/tools/apply-custom-tokens.mjs
+++ b/tools/apply-custom-tokens.mjs
@@ -1,0 +1,129 @@
+#!/usr/bin/env node
+
+import { readdir, readFile, writeFile } from 'node:fs/promises'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const repoRoot = resolve(__dirname, '..')
+const semanticTokensDir = join(repoRoot, 'design-tokens', 'semantic')
+
+const aliasMap = {
+  'text-subtle': ['icon-subtle'],
+}
+
+const isTokenObject = (value) => {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    !Array.isArray(value) &&
+    ('$type' in value || '$value' in value)
+  )
+}
+
+const cloneToken = (value) => JSON.parse(JSON.stringify(value))
+
+const applyAliases = (value) => {
+  if (Array.isArray(value)) {
+    return value.reduce((count, item) => count + applyAliases(item), 0)
+  }
+
+  if (!value || typeof value !== 'object') {
+    return 0
+  }
+
+  let changes = 0
+
+  for (const [sourceKey, aliasKeys] of Object.entries(aliasMap)) {
+    const sourceValue = value[sourceKey]
+
+    if (!isTokenObject(sourceValue)) {
+      continue
+    }
+
+    const insertAfterSource = Object.entries(value)
+    let inserted = 0
+
+    for (const aliasKey of aliasKeys) {
+      if (aliasKey in value) {
+        continue
+      }
+
+      inserted += 1
+      changes += 1
+      value[aliasKey] = cloneToken(sourceValue)
+    }
+
+    if (inserted > 0) {
+      const reordered = {}
+
+      for (const [key, entryValue] of insertAfterSource) {
+        reordered[key] = entryValue
+
+        if (key === sourceKey) {
+          for (const aliasKey of aliasKeys) {
+            if (aliasKey in value) {
+              reordered[aliasKey] = value[aliasKey]
+            }
+          }
+        }
+      }
+
+      for (const key of Object.keys(value)) {
+        delete value[key]
+      }
+
+      Object.assign(value, reordered)
+    }
+  }
+
+  for (const child of Object.values(value)) {
+    changes += applyAliases(child)
+  }
+
+  return changes
+}
+
+const collectJsonFiles = async (directory) => {
+  const entries = await readdir(directory, { withFileTypes: true })
+  const files = await Promise.all(
+    entries.map(async (entry) => {
+      const entryPath = join(directory, entry.name)
+
+      if (entry.isDirectory()) {
+        return collectJsonFiles(entryPath)
+      }
+
+      return entry.name.endsWith('.json') ? [entryPath] : []
+    }),
+  )
+
+  return files.flat()
+}
+
+const jsonFiles = await collectJsonFiles(semanticTokensDir)
+let updatedFiles = 0
+let createdAliases = 0
+
+for (const filePath of jsonFiles) {
+  const raw = await readFile(filePath, 'utf8')
+  const document = JSON.parse(raw)
+  const changes = applyAliases(document)
+
+  if (changes === 0) {
+    continue
+  }
+
+  await writeFile(filePath, `${JSON.stringify(document, null, 2)}\n`)
+  updatedFiles += 1
+  createdAliases += changes
+  console.log(`Updated ${filePath} (${changes} aliases)`)
+}
+
+if (updatedFiles === 0) {
+  console.log('No custom token aliases were added.')
+} else {
+  console.log(
+    `Added ${createdAliases} custom token aliases across ${updatedFiles} files.`,
+  )
+}

--- a/tools/apply-custom-tokens.mjs
+++ b/tools/apply-custom-tokens.mjs
@@ -1,5 +1,23 @@
 #!/usr/bin/env node
 
+/**
+ * Applies KS-specific token aliases that are not supported directly by the
+ * upstream Designsystemet theme generator.
+ *
+ 
+ * Usage:
+ *   node ./tools/apply-custom-tokens.mjs [tokens|outputs]
+ *
+ * Modes:
+ *   tokens   patches generated semantic token JSON in design-tokens/semantic
+ *   outputs  patches generated theme CSS files in packages/themes/src/themes
+ */
+
+// Supported key -> Our alias
+const aliasMap = {
+  'text-subtle': ['icon-subtle'],
+}
+
 import { readdir, readFile, writeFile } from 'node:fs/promises'
 import { dirname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -8,11 +26,7 @@ const __dirname = dirname(fileURLToPath(import.meta.url))
 const repoRoot = resolve(__dirname, '..')
 const semanticTokensDir = join(repoRoot, 'design-tokens', 'semantic')
 const themesDir = join(repoRoot, 'packages', 'themes', 'src', 'themes')
-const mode = process.argv[2] ?? 'all'
-
-const aliasMap = {
-  'text-subtle': ['icon-subtle'],
-}
+const mode = process.argv[2]
 
 const cloneTokenForAlias = (value, sourceKey, aliasKey) => {
   const clone = JSON.parse(JSON.stringify(value))
@@ -58,7 +72,7 @@ const applyAliases = (value) => {
       continue
     }
 
-    const insertAfterSource = Object.entries(value)
+    const snapshot = Object.entries(value)
     let inserted = 0
 
     for (const aliasKey of aliasKeys) {
@@ -84,7 +98,7 @@ const applyAliases = (value) => {
     if (inserted > 0) {
       const reordered = {}
 
-      for (const [key, entryValue] of insertAfterSource) {
+      for (const [key, entryValue] of snapshot) {
         reordered[key] = entryValue
 
         if (key === sourceKey) {
@@ -128,42 +142,27 @@ const collectJsonFiles = async (directory) => {
   return files.flat()
 }
 
-const collectTailwindFiles = async (directory) => {
+const collectCssFiles = async (directory, filter) => {
   try {
     const entries = await readdir(directory, { withFileTypes: true })
 
     return entries
-      .filter((entry) => entry.isFile() && entry.name.endsWith('.tailwind.css'))
+      .filter((entry) => entry.isFile() && filter(entry.name))
       .map((entry) => join(directory, entry.name))
   } catch (error) {
-    if (error && typeof error === 'object' && error.code === 'ENOENT') {
-      return []
-    }
-
+    if (error?.code === 'ENOENT') return []
     throw error
   }
 }
 
-const collectThemeCssFiles = async (directory) => {
-  try {
-    const entries = await readdir(directory, { withFileTypes: true })
+const collectTailwindFiles = (directory) =>
+  collectCssFiles(directory, (name) => name.endsWith('.tailwind.css'))
 
-    return entries
-      .filter(
-        (entry) =>
-          entry.isFile() &&
-          entry.name.endsWith('.css') &&
-          !entry.name.endsWith('.tailwind.css'),
-      )
-      .map((entry) => join(directory, entry.name))
-  } catch (error) {
-    if (error && typeof error === 'object' && error.code === 'ENOENT') {
-      return []
-    }
-
-    throw error
-  }
-}
+const collectThemeCssFiles = (directory) =>
+  collectCssFiles(
+    directory,
+    (name) => name.endsWith('.css') && !name.endsWith('.tailwind.css'),
+  )
 
 const applyThemeAliases = (content) => {
   const lines = content.split('\n')
@@ -308,61 +307,48 @@ const applyTokenAliases = async () => {
   )
 }
 
+const patchCssFiles = async (files, patchFn, label) => {
+  let count = 0
+
+  for (const filePath of files) {
+    const raw = await readFile(filePath, 'utf8')
+    const { changed, content } = patchFn(raw)
+
+    if (!changed) continue
+
+    await writeFile(filePath, content)
+    count += 1
+    console.log(`Patched ${label} in ${filePath}`)
+  }
+
+  console.log(
+    count === 0
+      ? `No ${label} patches were needed.`
+      : `Patched ${label} in ${count} files.`,
+  )
+}
+
 const patchBuildOutputs = async () => {
-  const tailwindFiles = await collectTailwindFiles(themesDir)
-  let updatedTailwindFiles = 0
-
-  for (const filePath of tailwindFiles) {
-    const raw = await readFile(filePath, 'utf8')
-    const { changed, content } = applyTailwindAliases(raw)
-
-    if (!changed) {
-      continue
-    }
-
-    await writeFile(filePath, content)
-    updatedTailwindFiles += 1
-    console.log(`Patched Tailwind aliases in ${filePath}`)
-  }
-
-  if (updatedTailwindFiles === 0) {
-    console.log('No Tailwind alias patches were needed.')
-  } else {
-    console.log(`Patched Tailwind aliases in ${updatedTailwindFiles} files.`)
-  }
-
-  const themeCssFiles = await collectThemeCssFiles(themesDir)
-  let updatedThemeCssFiles = 0
-
-  for (const filePath of themeCssFiles) {
-    const raw = await readFile(filePath, 'utf8')
-    const { changed, content } = applyThemeAliases(raw)
-
-    if (!changed) {
-      continue
-    }
-
-    await writeFile(filePath, content)
-    updatedThemeCssFiles += 1
-    console.log(`Patched theme aliases in ${filePath}`)
-  }
-
-  if (updatedThemeCssFiles === 0) {
-    console.log('No theme alias patches were needed.')
-    return
-  }
-
-  console.log(`Patched theme aliases in ${updatedThemeCssFiles} files.`)
+  await patchCssFiles(
+    await collectTailwindFiles(themesDir),
+    applyTailwindAliases,
+    'Tailwind aliases',
+  )
+  await patchCssFiles(
+    await collectThemeCssFiles(themesDir),
+    applyThemeAliases,
+    'theme aliases',
+  )
 }
 
-if (!['all', 'tokens', 'outputs'].includes(mode)) {
-  throw new Error(`Unsupported mode: ${mode}`)
+if (!['tokens', 'outputs'].includes(mode)) {
+  throw new Error(`Usage: apply-custom-tokens.mjs <tokens|outputs>`)
 }
 
-if (mode === 'all' || mode === 'tokens') {
+if (mode === 'tokens') {
   await applyTokenAliases()
 }
 
-if (mode === 'all' || mode === 'outputs') {
+if (mode === 'outputs') {
   await patchBuildOutputs()
 }


### PR DESCRIPTION

## What is the current behavior?


## What is the new behavior?
For each themes colors, add an `icon-subtle` which is an alias for `text-subtle` and a pipeline for possible further additions

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Checklist

- [ ] 📦 I have updated the public API (for example, if a new component was added)
- [ ] 🧪 Tests - I have added or updated tests that cover my changes (if applicable)
- [x] 📝 Documentation - I have updated relevant documentation, README, or comments (if applicable)
- [ ] 🔗 I have linked all related issues or discussions

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) describes this PR best?
