### PR TITLE
feat(themes): alias `icon-default` -> `text-default`

### DIFF
--- a/design-tokens/semantic/color.json
+++ b/design-tokens/semantic/color.json
@@ -49,6 +49,10 @@
         "$type": "color",
         "$value": "{color.accent.11}"
       },
+      "icon-default": {
+        "$type": "color",
+        "$value": "{color.accent.text-default}"
+      },
       "base-default": {
         "$type": "color",
         "$value": "{color.accent.12}"
@@ -118,6 +122,10 @@
       "text-default": {
         "$type": "color",
         "$value": "{color.neutral.11}"
+      },
+      "icon-default": {
+        "$type": "color",
+        "$value": "{color.neutral.text-default}"
       },
       "base-default": {
         "$type": "color",
@@ -189,6 +197,10 @@
         "$type": "color",
         "$value": "{color.support1.11}"
       },
+      "icon-default": {
+        "$type": "color",
+        "$value": "{color.support1.text-default}"
+      },
       "base-default": {
         "$type": "color",
         "$value": "{color.support1.12}"
@@ -258,6 +270,10 @@
       "text-default": {
         "$type": "color",
         "$value": "{color.support2.11}"
+      },
+      "icon-default": {
+        "$type": "color",
+        "$value": "{color.support2.text-default}"
       },
       "base-default": {
         "$type": "color",
@@ -329,6 +345,10 @@
         "$type": "color",
         "$value": "{color.info.11}"
       },
+      "icon-default": {
+        "$type": "color",
+        "$value": "{color.info.text-default}"
+      },
       "base-default": {
         "$type": "color",
         "$value": "{color.info.12}"
@@ -398,6 +418,10 @@
       "text-default": {
         "$type": "color",
         "$value": "{color.success.11}"
+      },
+      "icon-default": {
+        "$type": "color",
+        "$value": "{color.success.text-default}"
       },
       "base-default": {
         "$type": "color",
@@ -469,6 +493,10 @@
         "$type": "color",
         "$value": "{color.warning.11}"
       },
+      "icon-default": {
+        "$type": "color",
+        "$value": "{color.warning.text-default}"
+      },
       "base-default": {
         "$type": "color",
         "$value": "{color.warning.12}"
@@ -538,6 +566,10 @@
       "text-default": {
         "$type": "color",
         "$value": "{color.danger.11}"
+      },
+      "icon-default": {
+        "$type": "color",
+        "$value": "{color.danger.text-default}"
       },
       "base-default": {
         "$type": "color",

--- a/design-tokens/semantic/modes/main-color/accent.json
+++ b/design-tokens/semantic/modes/main-color/accent.json
@@ -49,6 +49,10 @@
         "$type": "color",
         "$value": "{color.accent.text-default}"
       },
+      "icon-default": {
+        "$type": "color",
+        "$value": "{color.accent.icon-default}"
+      },
       "base-default": {
         "$type": "color",
         "$value": "{color.accent.base-default}"

--- a/design-tokens/semantic/modes/support-color/support1.json
+++ b/design-tokens/semantic/modes/support-color/support1.json
@@ -49,6 +49,10 @@
         "$type": "color",
         "$value": "{color.support1.text-default}"
       },
+      "icon-default": {
+        "$type": "color",
+        "$value": "{color.support1.icon-default}"
+      },
       "base-default": {
         "$type": "color",
         "$value": "{color.support1.base-default}"

--- a/design-tokens/semantic/modes/support-color/support2.json
+++ b/design-tokens/semantic/modes/support-color/support2.json
@@ -49,6 +49,10 @@
         "$type": "color",
         "$value": "{color.support2.text-default}"
       },
+      "icon-default": {
+        "$type": "color",
+        "$value": "{color.support2.icon-default}"
+      },
       "base-default": {
         "$type": "color",
         "$value": "{color.support2.base-default}"

--- a/packages/themes/src/themes/ksdigital.css
+++ b/packages/themes/src/themes/ksdigital.css
@@ -131,6 +131,7 @@ design-tokens: v1.13.3
     --ds-color-accent-text-subtle: #595b77;
     --ds-color-accent-icon-subtle: #595b77;
     --ds-color-accent-text-default: #25284c;
+    --ds-color-accent-icon-default: #25284c;
     --ds-color-accent-base-default: #00042e;
     --ds-color-accent-base-hover: #151940;
     --ds-color-accent-base-active: #272a4e;
@@ -148,6 +149,7 @@ design-tokens: v1.13.3
     --ds-color-neutral-text-subtle: #585e64;
     --ds-color-neutral-icon-subtle: #585e64;
     --ds-color-neutral-text-default: #242c34;
+    --ds-color-neutral-icon-default: #242c34;
     --ds-color-neutral-base-default: #1d252d;
     --ds-color-neutral-base-hover: #2f363d;
     --ds-color-neutral-base-active: #41484f;
@@ -165,6 +167,7 @@ design-tokens: v1.13.3
     --ds-color-support1-text-subtle: #6244cb;
     --ds-color-support1-icon-subtle: #6244cb;
     --ds-color-support1-text-default: #2e2060;
+    --ds-color-support1-icon-default: #2e2060;
     --ds-color-support1-base-default: #714eea;
     --ds-color-support1-base-hover: #5d40c0;
     --ds-color-support1-base-active: #493297;
@@ -182,6 +185,7 @@ design-tokens: v1.13.3
     --ds-color-support2-text-subtle: #5d5d5d;
     --ds-color-support2-icon-subtle: #5d5d5d;
     --ds-color-support2-text-default: #2b2b2b;
+    --ds-color-support2-icon-default: #2b2b2b;
     --ds-color-support2-base-default: #ffffff;
     --ds-color-support2-base-hover: #e8e8e8;
     --ds-color-support2-base-active: #d1d1d1;
@@ -199,6 +203,7 @@ design-tokens: v1.13.3
     --ds-color-info-text-subtle: #0860a3;
     --ds-color-info-icon-subtle: #0860a3;
     --ds-color-info-text-default: #042d4d;
+    --ds-color-info-icon-default: #042d4d;
     --ds-color-info-base-default: #0a71c0;
     --ds-color-info-base-hover: #085d9f;
     --ds-color-info-base-active: #074a7e;
@@ -216,6 +221,7 @@ design-tokens: v1.13.3
     --ds-color-success-text-subtle: #056d13;
     --ds-color-success-icon-subtle: #056d13;
     --ds-color-success-text-default: #023409;
+    --ds-color-success-icon-default: #023409;
     --ds-color-success-base-default: #068718;
     --ds-color-success-base-hover: #057014;
     --ds-color-success-base-active: #045a10;
@@ -233,6 +239,7 @@ design-tokens: v1.13.3
     --ds-color-warning-text-subtle: #80540f;
     --ds-color-warning-icon-subtle: #80540f;
     --ds-color-warning-text-default: #3c2807;
+    --ds-color-warning-icon-default: #3c2807;
     --ds-color-warning-base-default: #ea9b1b;
     --ds-color-warning-base-hover: #cd8818;
     --ds-color-warning-base-active: #b27614;
@@ -250,6 +257,7 @@ design-tokens: v1.13.3
     --ds-color-danger-text-subtle: #b81a1a;
     --ds-color-danger-icon-subtle: #b81a1a;
     --ds-color-danger-text-default: #590d0d;
+    --ds-color-danger-icon-default: #590d0d;
     --ds-color-danger-base-default: #c01b1b;
     --ds-color-danger-base-hover: #9b1616;
     --ds-color-danger-base-active: #791111;
@@ -276,6 +284,7 @@ design-tokens: v1.13.3
       --ds-color-accent-text-subtle: #595b77;
       --ds-color-accent-icon-subtle: #595b77;
       --ds-color-accent-text-default: #25284c;
+      --ds-color-accent-icon-default: #25284c;
       --ds-color-accent-base-default: #00042e;
       --ds-color-accent-base-hover: #151940;
       --ds-color-accent-base-active: #272a4e;
@@ -293,6 +302,7 @@ design-tokens: v1.13.3
       --ds-color-neutral-text-subtle: #585e64;
       --ds-color-neutral-icon-subtle: #585e64;
       --ds-color-neutral-text-default: #242c34;
+      --ds-color-neutral-icon-default: #242c34;
       --ds-color-neutral-base-default: #1d252d;
       --ds-color-neutral-base-hover: #2f363d;
       --ds-color-neutral-base-active: #41484f;
@@ -310,6 +320,7 @@ design-tokens: v1.13.3
       --ds-color-support1-text-subtle: #6244cb;
       --ds-color-support1-icon-subtle: #6244cb;
       --ds-color-support1-text-default: #2e2060;
+      --ds-color-support1-icon-default: #2e2060;
       --ds-color-support1-base-default: #714eea;
       --ds-color-support1-base-hover: #5d40c0;
       --ds-color-support1-base-active: #493297;
@@ -327,6 +338,7 @@ design-tokens: v1.13.3
       --ds-color-support2-text-subtle: #5d5d5d;
       --ds-color-support2-icon-subtle: #5d5d5d;
       --ds-color-support2-text-default: #2b2b2b;
+      --ds-color-support2-icon-default: #2b2b2b;
       --ds-color-support2-base-default: #ffffff;
       --ds-color-support2-base-hover: #e8e8e8;
       --ds-color-support2-base-active: #d1d1d1;
@@ -344,6 +356,7 @@ design-tokens: v1.13.3
       --ds-color-info-text-subtle: #0860a3;
       --ds-color-info-icon-subtle: #0860a3;
       --ds-color-info-text-default: #042d4d;
+      --ds-color-info-icon-default: #042d4d;
       --ds-color-info-base-default: #0a71c0;
       --ds-color-info-base-hover: #085d9f;
       --ds-color-info-base-active: #074a7e;
@@ -361,6 +374,7 @@ design-tokens: v1.13.3
       --ds-color-success-text-subtle: #056d13;
       --ds-color-success-icon-subtle: #056d13;
       --ds-color-success-text-default: #023409;
+      --ds-color-success-icon-default: #023409;
       --ds-color-success-base-default: #068718;
       --ds-color-success-base-hover: #057014;
       --ds-color-success-base-active: #045a10;
@@ -378,6 +392,7 @@ design-tokens: v1.13.3
       --ds-color-warning-text-subtle: #80540f;
       --ds-color-warning-icon-subtle: #80540f;
       --ds-color-warning-text-default: #3c2807;
+      --ds-color-warning-icon-default: #3c2807;
       --ds-color-warning-base-default: #ea9b1b;
       --ds-color-warning-base-hover: #cd8818;
       --ds-color-warning-base-active: #b27614;
@@ -395,6 +410,7 @@ design-tokens: v1.13.3
       --ds-color-danger-text-subtle: #b81a1a;
       --ds-color-danger-icon-subtle: #b81a1a;
       --ds-color-danger-text-default: #590d0d;
+      --ds-color-danger-icon-default: #590d0d;
       --ds-color-danger-base-default: #c01b1b;
       --ds-color-danger-base-hover: #9b1616;
       --ds-color-danger-base-active: #791111;
@@ -607,6 +623,7 @@ design-tokens: v1.13.3
     --ds-color-accent-text-subtle: #a5a7b1;
     --ds-color-accent-icon-subtle: #a5a7b1;
     --ds-color-accent-text-default: #ececee;
+    --ds-color-accent-icon-default: #ececee;
     --ds-color-accent-base-default: #a9aab8;
     --ds-color-accent-base-hover: #9395a7;
     --ds-color-accent-base-active: #7e8095;
@@ -624,6 +641,7 @@ design-tokens: v1.13.3
     --ds-color-neutral-text-subtle: #a6a8aa;
     --ds-color-neutral-icon-subtle: #a6a8aa;
     --ds-color-neutral-text-default: #ececed;
+    --ds-color-neutral-icon-default: #ececed;
     --ds-color-neutral-base-default: #a8abae;
     --ds-color-neutral-base-hover: #93979a;
     --ds-color-neutral-base-active: #7d8286;
@@ -641,6 +659,7 @@ design-tokens: v1.13.3
     --ds-color-support1-text-subtle: #aaa0de;
     --ds-color-support1-icon-subtle: #aaa0de;
     --ds-color-support1-text-default: #edebf8;
+    --ds-color-support1-icon-default: #edebf8;
     --ds-color-support1-base-default: #896cee;
     --ds-color-support1-base-hover: #9f87f1;
     --ds-color-support1-base-active: #b3a0f4;
@@ -658,6 +677,7 @@ design-tokens: v1.13.3
     --ds-color-support2-text-subtle: #a8a8a8;
     --ds-color-support2-icon-subtle: #a8a8a8;
     --ds-color-support2-text-default: #ececec;
+    --ds-color-support2-icon-default: #ececec;
     --ds-color-support2-base-default: #000000;
     --ds-color-support2-base-hover: #181818;
     --ds-color-support2-base-active: #282828;
@@ -675,6 +695,7 @@ design-tokens: v1.13.3
     --ds-color-info-text-subtle: #8aabcb;
     --ds-color-info-icon-subtle: #8aabcb;
     --ds-color-info-text-default: #e6edf4;
+    --ds-color-info-icon-default: #e6edf4;
     --ds-color-info-base-default: #2d85c9;
     --ds-color-info-base-hover: #519ad2;
     --ds-color-info-base-active: #77b0dc;
@@ -692,6 +713,7 @@ design-tokens: v1.13.3
     --ds-color-success-text-subtle: #89b289;
     --ds-color-success-icon-subtle: #89b289;
     --ds-color-success-text-default: #e6efe6;
+    --ds-color-success-icon-default: #e6efe6;
     --ds-color-success-base-default: #138d24;
     --ds-color-success-base-hover: #3ca14b;
     --ds-color-success-base-active: #66b571;
@@ -709,6 +731,7 @@ design-tokens: v1.13.3
     --ds-color-warning-text-subtle: #d39e5b;
     --ds-color-warning-icon-subtle: #d39e5b;
     --ds-color-warning-text-default: #f7ebdb;
+    --ds-color-warning-icon-default: #f7ebdb;
     --ds-color-warning-base-default: #60400b;
     --ds-color-warning-base-hover: #7a510e;
     --ds-color-warning-base-active: #946211;
@@ -726,6 +749,7 @@ design-tokens: v1.13.3
     --ds-color-danger-text-subtle: #d19a96;
     --ds-color-danger-icon-subtle: #d19a96;
     --ds-color-danger-text-default: #f5eae9;
+    --ds-color-danger-icon-default: #f5eae9;
     --ds-color-danger-base-default: #d76e6e;
     --ds-color-danger-base-hover: #df8b8b;
     --ds-color-danger-base-active: #e7a8a8;
@@ -752,6 +776,7 @@ design-tokens: v1.13.3
       --ds-color-accent-text-subtle: #a5a7b1;
       --ds-color-accent-icon-subtle: #a5a7b1;
       --ds-color-accent-text-default: #ececee;
+      --ds-color-accent-icon-default: #ececee;
       --ds-color-accent-base-default: #a9aab8;
       --ds-color-accent-base-hover: #9395a7;
       --ds-color-accent-base-active: #7e8095;
@@ -769,6 +794,7 @@ design-tokens: v1.13.3
       --ds-color-neutral-text-subtle: #a6a8aa;
       --ds-color-neutral-icon-subtle: #a6a8aa;
       --ds-color-neutral-text-default: #ececed;
+      --ds-color-neutral-icon-default: #ececed;
       --ds-color-neutral-base-default: #a8abae;
       --ds-color-neutral-base-hover: #93979a;
       --ds-color-neutral-base-active: #7d8286;
@@ -786,6 +812,7 @@ design-tokens: v1.13.3
       --ds-color-support1-text-subtle: #aaa0de;
       --ds-color-support1-icon-subtle: #aaa0de;
       --ds-color-support1-text-default: #edebf8;
+      --ds-color-support1-icon-default: #edebf8;
       --ds-color-support1-base-default: #896cee;
       --ds-color-support1-base-hover: #9f87f1;
       --ds-color-support1-base-active: #b3a0f4;
@@ -803,6 +830,7 @@ design-tokens: v1.13.3
       --ds-color-support2-text-subtle: #a8a8a8;
       --ds-color-support2-icon-subtle: #a8a8a8;
       --ds-color-support2-text-default: #ececec;
+      --ds-color-support2-icon-default: #ececec;
       --ds-color-support2-base-default: #000000;
       --ds-color-support2-base-hover: #181818;
       --ds-color-support2-base-active: #282828;
@@ -820,6 +848,7 @@ design-tokens: v1.13.3
       --ds-color-info-text-subtle: #8aabcb;
       --ds-color-info-icon-subtle: #8aabcb;
       --ds-color-info-text-default: #e6edf4;
+      --ds-color-info-icon-default: #e6edf4;
       --ds-color-info-base-default: #2d85c9;
       --ds-color-info-base-hover: #519ad2;
       --ds-color-info-base-active: #77b0dc;
@@ -837,6 +866,7 @@ design-tokens: v1.13.3
       --ds-color-success-text-subtle: #89b289;
       --ds-color-success-icon-subtle: #89b289;
       --ds-color-success-text-default: #e6efe6;
+      --ds-color-success-icon-default: #e6efe6;
       --ds-color-success-base-default: #138d24;
       --ds-color-success-base-hover: #3ca14b;
       --ds-color-success-base-active: #66b571;
@@ -854,6 +884,7 @@ design-tokens: v1.13.3
       --ds-color-warning-text-subtle: #d39e5b;
       --ds-color-warning-icon-subtle: #d39e5b;
       --ds-color-warning-text-default: #f7ebdb;
+      --ds-color-warning-icon-default: #f7ebdb;
       --ds-color-warning-base-default: #60400b;
       --ds-color-warning-base-hover: #7a510e;
       --ds-color-warning-base-active: #946211;
@@ -871,6 +902,7 @@ design-tokens: v1.13.3
       --ds-color-danger-text-subtle: #d19a96;
       --ds-color-danger-icon-subtle: #d19a96;
       --ds-color-danger-text-default: #f5eae9;
+      --ds-color-danger-icon-default: #f5eae9;
       --ds-color-danger-base-default: #d76e6e;
       --ds-color-danger-base-hover: #df8b8b;
       --ds-color-danger-base-active: #e7a8a8;
@@ -988,6 +1020,7 @@ design-tokens: v1.13.3
     --ds-color-text-subtle: var(--ds-color-accent-text-subtle);
     --ds-color-icon-subtle: var(--ds-color-accent-icon-subtle);
     --ds-color-text-default: var(--ds-color-accent-text-default);
+    --ds-color-icon-default: var(--ds-color-accent-icon-default);
     --ds-color-base-default: var(--ds-color-accent-base-default);
     --ds-color-base-hover: var(--ds-color-accent-base-hover);
     --ds-color-base-active: var(--ds-color-accent-base-active);
@@ -1015,6 +1048,7 @@ design-tokens: v1.13.3
     --ds-color-text-subtle: var(--ds-color-danger-text-subtle);
     --ds-color-icon-subtle: var(--ds-color-danger-icon-subtle);
     --ds-color-text-default: var(--ds-color-danger-text-default);
+    --ds-color-icon-default: var(--ds-color-danger-icon-default);
     --ds-color-base-default: var(--ds-color-danger-base-default);
     --ds-color-base-hover: var(--ds-color-danger-base-hover);
     --ds-color-base-active: var(--ds-color-danger-base-active);
@@ -1042,6 +1076,7 @@ design-tokens: v1.13.3
     --ds-color-text-subtle: var(--ds-color-info-text-subtle);
     --ds-color-icon-subtle: var(--ds-color-info-icon-subtle);
     --ds-color-text-default: var(--ds-color-info-text-default);
+    --ds-color-icon-default: var(--ds-color-info-icon-default);
     --ds-color-base-default: var(--ds-color-info-base-default);
     --ds-color-base-hover: var(--ds-color-info-base-hover);
     --ds-color-base-active: var(--ds-color-info-base-active);
@@ -1067,6 +1102,7 @@ design-tokens: v1.13.3
     --ds-color-text-subtle: var(--ds-color-neutral-text-subtle);
     --ds-color-icon-subtle: var(--ds-color-neutral-icon-subtle);
     --ds-color-text-default: var(--ds-color-neutral-text-default);
+    --ds-color-icon-default: var(--ds-color-neutral-icon-default);
     --ds-color-base-default: var(--ds-color-neutral-base-default);
     --ds-color-base-hover: var(--ds-color-neutral-base-hover);
     --ds-color-base-active: var(--ds-color-neutral-base-active);
@@ -1094,6 +1130,7 @@ design-tokens: v1.13.3
     --ds-color-text-subtle: var(--ds-color-success-text-subtle);
     --ds-color-icon-subtle: var(--ds-color-success-icon-subtle);
     --ds-color-text-default: var(--ds-color-success-text-default);
+    --ds-color-icon-default: var(--ds-color-success-icon-default);
     --ds-color-base-default: var(--ds-color-success-base-default);
     --ds-color-base-hover: var(--ds-color-success-base-hover);
     --ds-color-base-active: var(--ds-color-success-base-active);
@@ -1121,6 +1158,7 @@ design-tokens: v1.13.3
     --ds-color-text-subtle: var(--ds-color-support1-text-subtle);
     --ds-color-icon-subtle: var(--ds-color-support1-icon-subtle);
     --ds-color-text-default: var(--ds-color-support1-text-default);
+    --ds-color-icon-default: var(--ds-color-support1-icon-default);
     --ds-color-base-default: var(--ds-color-support1-base-default);
     --ds-color-base-hover: var(--ds-color-support1-base-hover);
     --ds-color-base-active: var(--ds-color-support1-base-active);
@@ -1148,6 +1186,7 @@ design-tokens: v1.13.3
     --ds-color-text-subtle: var(--ds-color-support2-text-subtle);
     --ds-color-icon-subtle: var(--ds-color-support2-icon-subtle);
     --ds-color-text-default: var(--ds-color-support2-text-default);
+    --ds-color-icon-default: var(--ds-color-support2-icon-default);
     --ds-color-base-default: var(--ds-color-support2-base-default);
     --ds-color-base-hover: var(--ds-color-support2-base-hover);
     --ds-color-base-active: var(--ds-color-support2-base-active);
@@ -1175,6 +1214,7 @@ design-tokens: v1.13.3
     --ds-color-text-subtle: var(--ds-color-warning-text-subtle);
     --ds-color-icon-subtle: var(--ds-color-warning-icon-subtle);
     --ds-color-text-default: var(--ds-color-warning-text-default);
+    --ds-color-icon-default: var(--ds-color-warning-icon-default);
     --ds-color-base-default: var(--ds-color-warning-base-default);
     --ds-color-base-hover: var(--ds-color-warning-base-hover);
     --ds-color-base-active: var(--ds-color-warning-base-active);

--- a/packages/themes/src/themes/ksdigital.tailwind.css
+++ b/packages/themes/src/themes/ksdigital.tailwind.css
@@ -18,6 +18,7 @@
   --color-accent-border-default: var(--ds-color-accent-border-default);
   --color-accent-border-strong: var(--ds-color-accent-border-strong);
   --color-accent-border-subtle: var(--ds-color-accent-border-subtle);
+  --color-accent-icon-default: var(--ds-color-accent-icon-default);
   --color-accent-icon-subtle: var(--ds-color-accent-icon-subtle);
   --color-accent-surface-active: var(--ds-color-accent-surface-active);
   --color-accent-surface-default: var(--ds-color-accent-surface-default);
@@ -49,6 +50,7 @@
   --color-danger-border-default: var(--ds-color-danger-border-default);
   --color-danger-border-strong: var(--ds-color-danger-border-strong);
   --color-danger-border-subtle: var(--ds-color-danger-border-subtle);
+  --color-danger-icon-default: var(--ds-color-danger-icon-default);
   --color-danger-icon-subtle: var(--ds-color-danger-icon-subtle);
   --color-danger-surface-active: var(--ds-color-danger-surface-active);
   --color-danger-surface-default: var(--ds-color-danger-surface-default);
@@ -56,6 +58,7 @@
   --color-danger-surface-tinted: var(--ds-color-danger-surface-tinted);
   --color-danger-text-default: var(--ds-color-danger-text-default);
   --color-danger-text-subtle: var(--ds-color-danger-text-subtle);
+  --color-icon-default: var(--ds-color-icon-default);
   --color-icon-subtle: var(--ds-color-icon-subtle);
   --color-info-background-default: var(--ds-color-info-background-default);
   --color-info-background-tinted: var(--ds-color-info-background-tinted);
@@ -69,6 +72,7 @@
   --color-info-border-default: var(--ds-color-info-border-default);
   --color-info-border-strong: var(--ds-color-info-border-strong);
   --color-info-border-subtle: var(--ds-color-info-border-subtle);
+  --color-info-icon-default: var(--ds-color-info-icon-default);
   --color-info-icon-subtle: var(--ds-color-info-icon-subtle);
   --color-info-surface-active: var(--ds-color-info-surface-active);
   --color-info-surface-default: var(--ds-color-info-surface-default);
@@ -92,6 +96,7 @@
   --color-neutral-border-default: var(--ds-color-neutral-border-default);
   --color-neutral-border-strong: var(--ds-color-neutral-border-strong);
   --color-neutral-border-subtle: var(--ds-color-neutral-border-subtle);
+  --color-neutral-icon-default: var(--ds-color-neutral-icon-default);
   --color-neutral-icon-subtle: var(--ds-color-neutral-icon-subtle);
   --color-neutral-surface-active: var(--ds-color-neutral-surface-active);
   --color-neutral-surface-default: var(--ds-color-neutral-surface-default);
@@ -115,6 +120,7 @@
   --color-success-border-default: var(--ds-color-success-border-default);
   --color-success-border-strong: var(--ds-color-success-border-strong);
   --color-success-border-subtle: var(--ds-color-success-border-subtle);
+  --color-success-icon-default: var(--ds-color-success-icon-default);
   --color-success-icon-subtle: var(--ds-color-success-icon-subtle);
   --color-success-surface-active: var(--ds-color-success-surface-active);
   --color-success-surface-default: var(--ds-color-success-surface-default);
@@ -140,6 +146,7 @@
   --color-support1-border-default: var(--ds-color-support1-border-default);
   --color-support1-border-strong: var(--ds-color-support1-border-strong);
   --color-support1-border-subtle: var(--ds-color-support1-border-subtle);
+  --color-support1-icon-default: var(--ds-color-support1-icon-default);
   --color-support1-icon-subtle: var(--ds-color-support1-icon-subtle);
   --color-support1-surface-active: var(--ds-color-support1-surface-active);
   --color-support1-surface-default: var(--ds-color-support1-surface-default);
@@ -165,6 +172,7 @@
   --color-support2-border-default: var(--ds-color-support2-border-default);
   --color-support2-border-strong: var(--ds-color-support2-border-strong);
   --color-support2-border-subtle: var(--ds-color-support2-border-subtle);
+  --color-support2-icon-default: var(--ds-color-support2-icon-default);
   --color-support2-icon-subtle: var(--ds-color-support2-icon-subtle);
   --color-support2-surface-active: var(--ds-color-support2-surface-active);
   --color-support2-surface-default: var(--ds-color-support2-surface-default);
@@ -194,6 +202,7 @@
   --color-warning-border-default: var(--ds-color-warning-border-default);
   --color-warning-border-strong: var(--ds-color-warning-border-strong);
   --color-warning-border-subtle: var(--ds-color-warning-border-subtle);
+  --color-warning-icon-default: var(--ds-color-warning-icon-default);
   --color-warning-icon-subtle: var(--ds-color-warning-icon-subtle);
   --color-warning-surface-active: var(--ds-color-warning-surface-active);
   --color-warning-surface-default: var(--ds-color-warning-surface-default);
@@ -238,6 +247,7 @@
   --color-text-subtle: var(--ds-color-text-subtle);
   --color-icon-subtle: var(--ds-color-icon-subtle);
   --color-text-default: var(--ds-color-text-default);
+  --color-icon-default: var(--ds-color-icon-default);
   --color-base-default: var(--ds-color-base-default);
   --color-base-hover: var(--ds-color-base-hover);
   --color-base-active: var(--ds-color-base-active);

--- a/packages/themes/src/themes/ledsagerbevis.css
+++ b/packages/themes/src/themes/ledsagerbevis.css
@@ -131,6 +131,7 @@ design-tokens: v1.13.3
     --ds-color-accent-text-subtle: #416459;
     --ds-color-accent-icon-subtle: #416459;
     --ds-color-accent-text-default: #193029;
+    --ds-color-accent-icon-default: #193029;
     --ds-color-accent-base-default: #2b5246;
     --ds-color-accent-base-hover: #213f35;
     --ds-color-accent-base-active: #172b25;
@@ -148,6 +149,7 @@ design-tokens: v1.13.3
     --ds-color-neutral-text-subtle: #5a5e5d;
     --ds-color-neutral-icon-subtle: #5a5e5d;
     --ds-color-neutral-text-default: #272d2b;
+    --ds-color-neutral-icon-default: #272d2b;
     --ds-color-neutral-base-default: #1e2422;
     --ds-color-neutral-base-hover: #303533;
     --ds-color-neutral-base-active: #424745;
@@ -165,6 +167,7 @@ design-tokens: v1.13.3
     --ds-color-support1-text-subtle: #106a50;
     --ds-color-support1-icon-subtle: #106a50;
     --ds-color-support1-text-default: #083225;
+    --ds-color-support1-icon-default: #083225;
     --ds-color-support1-base-default: #1aa87e;
     --ds-color-support1-base-hover: #4dbb9b;
     --ds-color-support1-base-active: #7eceb7;
@@ -182,6 +185,7 @@ design-tokens: v1.13.3
     --ds-color-support2-text-subtle: #5d5d5d;
     --ds-color-support2-icon-subtle: #5d5d5d;
     --ds-color-support2-text-default: #2b2b2b;
+    --ds-color-support2-icon-default: #2b2b2b;
     --ds-color-support2-base-default: #ffffff;
     --ds-color-support2-base-hover: #e8e8e8;
     --ds-color-support2-base-active: #d1d1d1;
@@ -199,6 +203,7 @@ design-tokens: v1.13.3
     --ds-color-info-text-subtle: #0860a3;
     --ds-color-info-icon-subtle: #0860a3;
     --ds-color-info-text-default: #042d4d;
+    --ds-color-info-icon-default: #042d4d;
     --ds-color-info-base-default: #0a71c0;
     --ds-color-info-base-hover: #085d9f;
     --ds-color-info-base-active: #074a7e;
@@ -216,6 +221,7 @@ design-tokens: v1.13.3
     --ds-color-success-text-subtle: #056d13;
     --ds-color-success-icon-subtle: #056d13;
     --ds-color-success-text-default: #023409;
+    --ds-color-success-icon-default: #023409;
     --ds-color-success-base-default: #068718;
     --ds-color-success-base-hover: #057014;
     --ds-color-success-base-active: #045a10;
@@ -233,6 +239,7 @@ design-tokens: v1.13.3
     --ds-color-warning-text-subtle: #80540f;
     --ds-color-warning-icon-subtle: #80540f;
     --ds-color-warning-text-default: #3c2807;
+    --ds-color-warning-icon-default: #3c2807;
     --ds-color-warning-base-default: #ea9b1b;
     --ds-color-warning-base-hover: #cd8818;
     --ds-color-warning-base-active: #b27614;
@@ -250,6 +257,7 @@ design-tokens: v1.13.3
     --ds-color-danger-text-subtle: #b81a1a;
     --ds-color-danger-icon-subtle: #b81a1a;
     --ds-color-danger-text-default: #590d0d;
+    --ds-color-danger-icon-default: #590d0d;
     --ds-color-danger-base-default: #c01b1b;
     --ds-color-danger-base-hover: #9b1616;
     --ds-color-danger-base-active: #791111;
@@ -276,6 +284,7 @@ design-tokens: v1.13.3
       --ds-color-accent-text-subtle: #416459;
       --ds-color-accent-icon-subtle: #416459;
       --ds-color-accent-text-default: #193029;
+      --ds-color-accent-icon-default: #193029;
       --ds-color-accent-base-default: #2b5246;
       --ds-color-accent-base-hover: #213f35;
       --ds-color-accent-base-active: #172b25;
@@ -293,6 +302,7 @@ design-tokens: v1.13.3
       --ds-color-neutral-text-subtle: #5a5e5d;
       --ds-color-neutral-icon-subtle: #5a5e5d;
       --ds-color-neutral-text-default: #272d2b;
+      --ds-color-neutral-icon-default: #272d2b;
       --ds-color-neutral-base-default: #1e2422;
       --ds-color-neutral-base-hover: #303533;
       --ds-color-neutral-base-active: #424745;
@@ -310,6 +320,7 @@ design-tokens: v1.13.3
       --ds-color-support1-text-subtle: #106a50;
       --ds-color-support1-icon-subtle: #106a50;
       --ds-color-support1-text-default: #083225;
+      --ds-color-support1-icon-default: #083225;
       --ds-color-support1-base-default: #1aa87e;
       --ds-color-support1-base-hover: #4dbb9b;
       --ds-color-support1-base-active: #7eceb7;
@@ -327,6 +338,7 @@ design-tokens: v1.13.3
       --ds-color-support2-text-subtle: #5d5d5d;
       --ds-color-support2-icon-subtle: #5d5d5d;
       --ds-color-support2-text-default: #2b2b2b;
+      --ds-color-support2-icon-default: #2b2b2b;
       --ds-color-support2-base-default: #ffffff;
       --ds-color-support2-base-hover: #e8e8e8;
       --ds-color-support2-base-active: #d1d1d1;
@@ -344,6 +356,7 @@ design-tokens: v1.13.3
       --ds-color-info-text-subtle: #0860a3;
       --ds-color-info-icon-subtle: #0860a3;
       --ds-color-info-text-default: #042d4d;
+      --ds-color-info-icon-default: #042d4d;
       --ds-color-info-base-default: #0a71c0;
       --ds-color-info-base-hover: #085d9f;
       --ds-color-info-base-active: #074a7e;
@@ -361,6 +374,7 @@ design-tokens: v1.13.3
       --ds-color-success-text-subtle: #056d13;
       --ds-color-success-icon-subtle: #056d13;
       --ds-color-success-text-default: #023409;
+      --ds-color-success-icon-default: #023409;
       --ds-color-success-base-default: #068718;
       --ds-color-success-base-hover: #057014;
       --ds-color-success-base-active: #045a10;
@@ -378,6 +392,7 @@ design-tokens: v1.13.3
       --ds-color-warning-text-subtle: #80540f;
       --ds-color-warning-icon-subtle: #80540f;
       --ds-color-warning-text-default: #3c2807;
+      --ds-color-warning-icon-default: #3c2807;
       --ds-color-warning-base-default: #ea9b1b;
       --ds-color-warning-base-hover: #cd8818;
       --ds-color-warning-base-active: #b27614;
@@ -395,6 +410,7 @@ design-tokens: v1.13.3
       --ds-color-danger-text-subtle: #b81a1a;
       --ds-color-danger-icon-subtle: #b81a1a;
       --ds-color-danger-text-default: #590d0d;
+      --ds-color-danger-icon-default: #590d0d;
       --ds-color-danger-base-default: #c01b1b;
       --ds-color-danger-base-hover: #9b1616;
       --ds-color-danger-base-active: #791111;
@@ -607,6 +623,7 @@ design-tokens: v1.13.3
     --ds-color-accent-text-subtle: #9eaaa7;
     --ds-color-accent-icon-subtle: #9eaaa7;
     --ds-color-accent-text-default: #eaedec;
+    --ds-color-accent-icon-default: #eaedec;
     --ds-color-accent-base-default: #97aaa4;
     --ds-color-accent-base-hover: #7f968f;
     --ds-color-accent-base-active: #67837a;
@@ -624,6 +641,7 @@ design-tokens: v1.13.3
     --ds-color-neutral-text-subtle: #a6a8a7;
     --ds-color-neutral-icon-subtle: #a6a8a7;
     --ds-color-neutral-text-default: #ececec;
+    --ds-color-neutral-icon-default: #ececec;
     --ds-color-neutral-base-default: #a9acab;
     --ds-color-neutral-base-hover: #949796;
     --ds-color-neutral-base-active: #7e8281;
@@ -641,6 +659,7 @@ design-tokens: v1.13.3
     --ds-color-support1-text-subtle: #76b49c;
     --ds-color-support1-icon-subtle: #76b49c;
     --ds-color-support1-text-default: #e2efea;
+    --ds-color-support1-icon-default: #e2efea;
     --ds-color-support1-base-default: #10684e;
     --ds-color-support1-base-hover: #0d523e;
     --ds-color-support1-base-active: #0a3e2e;
@@ -658,6 +677,7 @@ design-tokens: v1.13.3
     --ds-color-support2-text-subtle: #a8a8a8;
     --ds-color-support2-icon-subtle: #a8a8a8;
     --ds-color-support2-text-default: #ececec;
+    --ds-color-support2-icon-default: #ececec;
     --ds-color-support2-base-default: #000000;
     --ds-color-support2-base-hover: #181818;
     --ds-color-support2-base-active: #282828;
@@ -675,6 +695,7 @@ design-tokens: v1.13.3
     --ds-color-info-text-subtle: #8aabcb;
     --ds-color-info-icon-subtle: #8aabcb;
     --ds-color-info-text-default: #e6edf4;
+    --ds-color-info-icon-default: #e6edf4;
     --ds-color-info-base-default: #2d85c9;
     --ds-color-info-base-hover: #519ad2;
     --ds-color-info-base-active: #77b0dc;
@@ -692,6 +713,7 @@ design-tokens: v1.13.3
     --ds-color-success-text-subtle: #89b289;
     --ds-color-success-icon-subtle: #89b289;
     --ds-color-success-text-default: #e6efe6;
+    --ds-color-success-icon-default: #e6efe6;
     --ds-color-success-base-default: #138d24;
     --ds-color-success-base-hover: #3ca14b;
     --ds-color-success-base-active: #66b571;
@@ -709,6 +731,7 @@ design-tokens: v1.13.3
     --ds-color-warning-text-subtle: #d39e5b;
     --ds-color-warning-icon-subtle: #d39e5b;
     --ds-color-warning-text-default: #f7ebdb;
+    --ds-color-warning-icon-default: #f7ebdb;
     --ds-color-warning-base-default: #60400b;
     --ds-color-warning-base-hover: #7a510e;
     --ds-color-warning-base-active: #946211;
@@ -726,6 +749,7 @@ design-tokens: v1.13.3
     --ds-color-danger-text-subtle: #d19a96;
     --ds-color-danger-icon-subtle: #d19a96;
     --ds-color-danger-text-default: #f5eae9;
+    --ds-color-danger-icon-default: #f5eae9;
     --ds-color-danger-base-default: #d76e6e;
     --ds-color-danger-base-hover: #df8b8b;
     --ds-color-danger-base-active: #e7a8a8;
@@ -752,6 +776,7 @@ design-tokens: v1.13.3
       --ds-color-accent-text-subtle: #9eaaa7;
       --ds-color-accent-icon-subtle: #9eaaa7;
       --ds-color-accent-text-default: #eaedec;
+      --ds-color-accent-icon-default: #eaedec;
       --ds-color-accent-base-default: #97aaa4;
       --ds-color-accent-base-hover: #7f968f;
       --ds-color-accent-base-active: #67837a;
@@ -769,6 +794,7 @@ design-tokens: v1.13.3
       --ds-color-neutral-text-subtle: #a6a8a7;
       --ds-color-neutral-icon-subtle: #a6a8a7;
       --ds-color-neutral-text-default: #ececec;
+      --ds-color-neutral-icon-default: #ececec;
       --ds-color-neutral-base-default: #a9acab;
       --ds-color-neutral-base-hover: #949796;
       --ds-color-neutral-base-active: #7e8281;
@@ -786,6 +812,7 @@ design-tokens: v1.13.3
       --ds-color-support1-text-subtle: #76b49c;
       --ds-color-support1-icon-subtle: #76b49c;
       --ds-color-support1-text-default: #e2efea;
+      --ds-color-support1-icon-default: #e2efea;
       --ds-color-support1-base-default: #10684e;
       --ds-color-support1-base-hover: #0d523e;
       --ds-color-support1-base-active: #0a3e2e;
@@ -803,6 +830,7 @@ design-tokens: v1.13.3
       --ds-color-support2-text-subtle: #a8a8a8;
       --ds-color-support2-icon-subtle: #a8a8a8;
       --ds-color-support2-text-default: #ececec;
+      --ds-color-support2-icon-default: #ececec;
       --ds-color-support2-base-default: #000000;
       --ds-color-support2-base-hover: #181818;
       --ds-color-support2-base-active: #282828;
@@ -820,6 +848,7 @@ design-tokens: v1.13.3
       --ds-color-info-text-subtle: #8aabcb;
       --ds-color-info-icon-subtle: #8aabcb;
       --ds-color-info-text-default: #e6edf4;
+      --ds-color-info-icon-default: #e6edf4;
       --ds-color-info-base-default: #2d85c9;
       --ds-color-info-base-hover: #519ad2;
       --ds-color-info-base-active: #77b0dc;
@@ -837,6 +866,7 @@ design-tokens: v1.13.3
       --ds-color-success-text-subtle: #89b289;
       --ds-color-success-icon-subtle: #89b289;
       --ds-color-success-text-default: #e6efe6;
+      --ds-color-success-icon-default: #e6efe6;
       --ds-color-success-base-default: #138d24;
       --ds-color-success-base-hover: #3ca14b;
       --ds-color-success-base-active: #66b571;
@@ -854,6 +884,7 @@ design-tokens: v1.13.3
       --ds-color-warning-text-subtle: #d39e5b;
       --ds-color-warning-icon-subtle: #d39e5b;
       --ds-color-warning-text-default: #f7ebdb;
+      --ds-color-warning-icon-default: #f7ebdb;
       --ds-color-warning-base-default: #60400b;
       --ds-color-warning-base-hover: #7a510e;
       --ds-color-warning-base-active: #946211;
@@ -871,6 +902,7 @@ design-tokens: v1.13.3
       --ds-color-danger-text-subtle: #d19a96;
       --ds-color-danger-icon-subtle: #d19a96;
       --ds-color-danger-text-default: #f5eae9;
+      --ds-color-danger-icon-default: #f5eae9;
       --ds-color-danger-base-default: #d76e6e;
       --ds-color-danger-base-hover: #df8b8b;
       --ds-color-danger-base-active: #e7a8a8;
@@ -988,6 +1020,7 @@ design-tokens: v1.13.3
     --ds-color-text-subtle: var(--ds-color-accent-text-subtle);
     --ds-color-icon-subtle: var(--ds-color-accent-icon-subtle);
     --ds-color-text-default: var(--ds-color-accent-text-default);
+    --ds-color-icon-default: var(--ds-color-accent-icon-default);
     --ds-color-base-default: var(--ds-color-accent-base-default);
     --ds-color-base-hover: var(--ds-color-accent-base-hover);
     --ds-color-base-active: var(--ds-color-accent-base-active);
@@ -1015,6 +1048,7 @@ design-tokens: v1.13.3
     --ds-color-text-subtle: var(--ds-color-danger-text-subtle);
     --ds-color-icon-subtle: var(--ds-color-danger-icon-subtle);
     --ds-color-text-default: var(--ds-color-danger-text-default);
+    --ds-color-icon-default: var(--ds-color-danger-icon-default);
     --ds-color-base-default: var(--ds-color-danger-base-default);
     --ds-color-base-hover: var(--ds-color-danger-base-hover);
     --ds-color-base-active: var(--ds-color-danger-base-active);
@@ -1042,6 +1076,7 @@ design-tokens: v1.13.3
     --ds-color-text-subtle: var(--ds-color-info-text-subtle);
     --ds-color-icon-subtle: var(--ds-color-info-icon-subtle);
     --ds-color-text-default: var(--ds-color-info-text-default);
+    --ds-color-icon-default: var(--ds-color-info-icon-default);
     --ds-color-base-default: var(--ds-color-info-base-default);
     --ds-color-base-hover: var(--ds-color-info-base-hover);
     --ds-color-base-active: var(--ds-color-info-base-active);
@@ -1067,6 +1102,7 @@ design-tokens: v1.13.3
     --ds-color-text-subtle: var(--ds-color-neutral-text-subtle);
     --ds-color-icon-subtle: var(--ds-color-neutral-icon-subtle);
     --ds-color-text-default: var(--ds-color-neutral-text-default);
+    --ds-color-icon-default: var(--ds-color-neutral-icon-default);
     --ds-color-base-default: var(--ds-color-neutral-base-default);
     --ds-color-base-hover: var(--ds-color-neutral-base-hover);
     --ds-color-base-active: var(--ds-color-neutral-base-active);
@@ -1094,6 +1130,7 @@ design-tokens: v1.13.3
     --ds-color-text-subtle: var(--ds-color-success-text-subtle);
     --ds-color-icon-subtle: var(--ds-color-success-icon-subtle);
     --ds-color-text-default: var(--ds-color-success-text-default);
+    --ds-color-icon-default: var(--ds-color-success-icon-default);
     --ds-color-base-default: var(--ds-color-success-base-default);
     --ds-color-base-hover: var(--ds-color-success-base-hover);
     --ds-color-base-active: var(--ds-color-success-base-active);
@@ -1121,6 +1158,7 @@ design-tokens: v1.13.3
     --ds-color-text-subtle: var(--ds-color-support1-text-subtle);
     --ds-color-icon-subtle: var(--ds-color-support1-icon-subtle);
     --ds-color-text-default: var(--ds-color-support1-text-default);
+    --ds-color-icon-default: var(--ds-color-support1-icon-default);
     --ds-color-base-default: var(--ds-color-support1-base-default);
     --ds-color-base-hover: var(--ds-color-support1-base-hover);
     --ds-color-base-active: var(--ds-color-support1-base-active);
@@ -1148,6 +1186,7 @@ design-tokens: v1.13.3
     --ds-color-text-subtle: var(--ds-color-support2-text-subtle);
     --ds-color-icon-subtle: var(--ds-color-support2-icon-subtle);
     --ds-color-text-default: var(--ds-color-support2-text-default);
+    --ds-color-icon-default: var(--ds-color-support2-icon-default);
     --ds-color-base-default: var(--ds-color-support2-base-default);
     --ds-color-base-hover: var(--ds-color-support2-base-hover);
     --ds-color-base-active: var(--ds-color-support2-base-active);
@@ -1175,6 +1214,7 @@ design-tokens: v1.13.3
     --ds-color-text-subtle: var(--ds-color-warning-text-subtle);
     --ds-color-icon-subtle: var(--ds-color-warning-icon-subtle);
     --ds-color-text-default: var(--ds-color-warning-text-default);
+    --ds-color-icon-default: var(--ds-color-warning-icon-default);
     --ds-color-base-default: var(--ds-color-warning-base-default);
     --ds-color-base-hover: var(--ds-color-warning-base-hover);
     --ds-color-base-active: var(--ds-color-warning-base-active);

--- a/packages/themes/src/themes/ledsagerbevis.tailwind.css
+++ b/packages/themes/src/themes/ledsagerbevis.tailwind.css
@@ -18,6 +18,7 @@
   --color-accent-border-default: var(--ds-color-accent-border-default);
   --color-accent-border-strong: var(--ds-color-accent-border-strong);
   --color-accent-border-subtle: var(--ds-color-accent-border-subtle);
+  --color-accent-icon-default: var(--ds-color-accent-icon-default);
   --color-accent-icon-subtle: var(--ds-color-accent-icon-subtle);
   --color-accent-surface-active: var(--ds-color-accent-surface-active);
   --color-accent-surface-default: var(--ds-color-accent-surface-default);
@@ -49,6 +50,7 @@
   --color-danger-border-default: var(--ds-color-danger-border-default);
   --color-danger-border-strong: var(--ds-color-danger-border-strong);
   --color-danger-border-subtle: var(--ds-color-danger-border-subtle);
+  --color-danger-icon-default: var(--ds-color-danger-icon-default);
   --color-danger-icon-subtle: var(--ds-color-danger-icon-subtle);
   --color-danger-surface-active: var(--ds-color-danger-surface-active);
   --color-danger-surface-default: var(--ds-color-danger-surface-default);
@@ -56,6 +58,7 @@
   --color-danger-surface-tinted: var(--ds-color-danger-surface-tinted);
   --color-danger-text-default: var(--ds-color-danger-text-default);
   --color-danger-text-subtle: var(--ds-color-danger-text-subtle);
+  --color-icon-default: var(--ds-color-icon-default);
   --color-icon-subtle: var(--ds-color-icon-subtle);
   --color-info-background-default: var(--ds-color-info-background-default);
   --color-info-background-tinted: var(--ds-color-info-background-tinted);
@@ -69,6 +72,7 @@
   --color-info-border-default: var(--ds-color-info-border-default);
   --color-info-border-strong: var(--ds-color-info-border-strong);
   --color-info-border-subtle: var(--ds-color-info-border-subtle);
+  --color-info-icon-default: var(--ds-color-info-icon-default);
   --color-info-icon-subtle: var(--ds-color-info-icon-subtle);
   --color-info-surface-active: var(--ds-color-info-surface-active);
   --color-info-surface-default: var(--ds-color-info-surface-default);
@@ -92,6 +96,7 @@
   --color-neutral-border-default: var(--ds-color-neutral-border-default);
   --color-neutral-border-strong: var(--ds-color-neutral-border-strong);
   --color-neutral-border-subtle: var(--ds-color-neutral-border-subtle);
+  --color-neutral-icon-default: var(--ds-color-neutral-icon-default);
   --color-neutral-icon-subtle: var(--ds-color-neutral-icon-subtle);
   --color-neutral-surface-active: var(--ds-color-neutral-surface-active);
   --color-neutral-surface-default: var(--ds-color-neutral-surface-default);
@@ -115,6 +120,7 @@
   --color-success-border-default: var(--ds-color-success-border-default);
   --color-success-border-strong: var(--ds-color-success-border-strong);
   --color-success-border-subtle: var(--ds-color-success-border-subtle);
+  --color-success-icon-default: var(--ds-color-success-icon-default);
   --color-success-icon-subtle: var(--ds-color-success-icon-subtle);
   --color-success-surface-active: var(--ds-color-success-surface-active);
   --color-success-surface-default: var(--ds-color-success-surface-default);
@@ -140,6 +146,7 @@
   --color-support1-border-default: var(--ds-color-support1-border-default);
   --color-support1-border-strong: var(--ds-color-support1-border-strong);
   --color-support1-border-subtle: var(--ds-color-support1-border-subtle);
+  --color-support1-icon-default: var(--ds-color-support1-icon-default);
   --color-support1-icon-subtle: var(--ds-color-support1-icon-subtle);
   --color-support1-surface-active: var(--ds-color-support1-surface-active);
   --color-support1-surface-default: var(--ds-color-support1-surface-default);
@@ -165,6 +172,7 @@
   --color-support2-border-default: var(--ds-color-support2-border-default);
   --color-support2-border-strong: var(--ds-color-support2-border-strong);
   --color-support2-border-subtle: var(--ds-color-support2-border-subtle);
+  --color-support2-icon-default: var(--ds-color-support2-icon-default);
   --color-support2-icon-subtle: var(--ds-color-support2-icon-subtle);
   --color-support2-surface-active: var(--ds-color-support2-surface-active);
   --color-support2-surface-default: var(--ds-color-support2-surface-default);
@@ -194,6 +202,7 @@
   --color-warning-border-default: var(--ds-color-warning-border-default);
   --color-warning-border-strong: var(--ds-color-warning-border-strong);
   --color-warning-border-subtle: var(--ds-color-warning-border-subtle);
+  --color-warning-icon-default: var(--ds-color-warning-icon-default);
   --color-warning-icon-subtle: var(--ds-color-warning-icon-subtle);
   --color-warning-surface-active: var(--ds-color-warning-surface-active);
   --color-warning-surface-default: var(--ds-color-warning-surface-default);
@@ -238,6 +247,7 @@
   --color-text-subtle: var(--ds-color-text-subtle);
   --color-icon-subtle: var(--ds-color-icon-subtle);
   --color-text-default: var(--ds-color-text-default);
+  --color-icon-default: var(--ds-color-icon-default);
   --color-base-default: var(--ds-color-base-default);
   --color-base-hover: var(--ds-color-base-hover);
   --color-base-active: var(--ds-color-base-active);

--- a/packages/themes/src/themes/minkommune.css
+++ b/packages/themes/src/themes/minkommune.css
@@ -131,6 +131,7 @@ design-tokens: v1.13.3
     --ds-color-accent-text-subtle: #595b77;
     --ds-color-accent-icon-subtle: #595b77;
     --ds-color-accent-text-default: #25284c;
+    --ds-color-accent-icon-default: #25284c;
     --ds-color-accent-base-default: #00042e;
     --ds-color-accent-base-hover: #151940;
     --ds-color-accent-base-active: #272a4e;
@@ -148,6 +149,7 @@ design-tokens: v1.13.3
     --ds-color-neutral-text-subtle: #585e64;
     --ds-color-neutral-icon-subtle: #585e64;
     --ds-color-neutral-text-default: #242c34;
+    --ds-color-neutral-icon-default: #242c34;
     --ds-color-neutral-base-default: #1d252d;
     --ds-color-neutral-base-hover: #2f363d;
     --ds-color-neutral-base-active: #41484f;
@@ -165,6 +167,7 @@ design-tokens: v1.13.3
     --ds-color-support1-text-subtle: #6244cb;
     --ds-color-support1-icon-subtle: #6244cb;
     --ds-color-support1-text-default: #2e2060;
+    --ds-color-support1-icon-default: #2e2060;
     --ds-color-support1-base-default: #714eea;
     --ds-color-support1-base-hover: #5d40c0;
     --ds-color-support1-base-active: #493297;
@@ -182,6 +185,7 @@ design-tokens: v1.13.3
     --ds-color-support2-text-subtle: #5d5d5d;
     --ds-color-support2-icon-subtle: #5d5d5d;
     --ds-color-support2-text-default: #2b2b2b;
+    --ds-color-support2-icon-default: #2b2b2b;
     --ds-color-support2-base-default: #ffffff;
     --ds-color-support2-base-hover: #e8e8e8;
     --ds-color-support2-base-active: #d1d1d1;
@@ -199,6 +203,7 @@ design-tokens: v1.13.3
     --ds-color-info-text-subtle: #0860a3;
     --ds-color-info-icon-subtle: #0860a3;
     --ds-color-info-text-default: #042d4d;
+    --ds-color-info-icon-default: #042d4d;
     --ds-color-info-base-default: #0a71c0;
     --ds-color-info-base-hover: #085d9f;
     --ds-color-info-base-active: #074a7e;
@@ -216,6 +221,7 @@ design-tokens: v1.13.3
     --ds-color-success-text-subtle: #056d13;
     --ds-color-success-icon-subtle: #056d13;
     --ds-color-success-text-default: #023409;
+    --ds-color-success-icon-default: #023409;
     --ds-color-success-base-default: #068718;
     --ds-color-success-base-hover: #057014;
     --ds-color-success-base-active: #045a10;
@@ -233,6 +239,7 @@ design-tokens: v1.13.3
     --ds-color-warning-text-subtle: #80540f;
     --ds-color-warning-icon-subtle: #80540f;
     --ds-color-warning-text-default: #3c2807;
+    --ds-color-warning-icon-default: #3c2807;
     --ds-color-warning-base-default: #ea9b1b;
     --ds-color-warning-base-hover: #cd8818;
     --ds-color-warning-base-active: #b27614;
@@ -250,6 +257,7 @@ design-tokens: v1.13.3
     --ds-color-danger-text-subtle: #b81a1a;
     --ds-color-danger-icon-subtle: #b81a1a;
     --ds-color-danger-text-default: #590d0d;
+    --ds-color-danger-icon-default: #590d0d;
     --ds-color-danger-base-default: #c01b1b;
     --ds-color-danger-base-hover: #9b1616;
     --ds-color-danger-base-active: #791111;
@@ -276,6 +284,7 @@ design-tokens: v1.13.3
       --ds-color-accent-text-subtle: #595b77;
       --ds-color-accent-icon-subtle: #595b77;
       --ds-color-accent-text-default: #25284c;
+      --ds-color-accent-icon-default: #25284c;
       --ds-color-accent-base-default: #00042e;
       --ds-color-accent-base-hover: #151940;
       --ds-color-accent-base-active: #272a4e;
@@ -293,6 +302,7 @@ design-tokens: v1.13.3
       --ds-color-neutral-text-subtle: #585e64;
       --ds-color-neutral-icon-subtle: #585e64;
       --ds-color-neutral-text-default: #242c34;
+      --ds-color-neutral-icon-default: #242c34;
       --ds-color-neutral-base-default: #1d252d;
       --ds-color-neutral-base-hover: #2f363d;
       --ds-color-neutral-base-active: #41484f;
@@ -310,6 +320,7 @@ design-tokens: v1.13.3
       --ds-color-support1-text-subtle: #6244cb;
       --ds-color-support1-icon-subtle: #6244cb;
       --ds-color-support1-text-default: #2e2060;
+      --ds-color-support1-icon-default: #2e2060;
       --ds-color-support1-base-default: #714eea;
       --ds-color-support1-base-hover: #5d40c0;
       --ds-color-support1-base-active: #493297;
@@ -327,6 +338,7 @@ design-tokens: v1.13.3
       --ds-color-support2-text-subtle: #5d5d5d;
       --ds-color-support2-icon-subtle: #5d5d5d;
       --ds-color-support2-text-default: #2b2b2b;
+      --ds-color-support2-icon-default: #2b2b2b;
       --ds-color-support2-base-default: #ffffff;
       --ds-color-support2-base-hover: #e8e8e8;
       --ds-color-support2-base-active: #d1d1d1;
@@ -344,6 +356,7 @@ design-tokens: v1.13.3
       --ds-color-info-text-subtle: #0860a3;
       --ds-color-info-icon-subtle: #0860a3;
       --ds-color-info-text-default: #042d4d;
+      --ds-color-info-icon-default: #042d4d;
       --ds-color-info-base-default: #0a71c0;
       --ds-color-info-base-hover: #085d9f;
       --ds-color-info-base-active: #074a7e;
@@ -361,6 +374,7 @@ design-tokens: v1.13.3
       --ds-color-success-text-subtle: #056d13;
       --ds-color-success-icon-subtle: #056d13;
       --ds-color-success-text-default: #023409;
+      --ds-color-success-icon-default: #023409;
       --ds-color-success-base-default: #068718;
       --ds-color-success-base-hover: #057014;
       --ds-color-success-base-active: #045a10;
@@ -378,6 +392,7 @@ design-tokens: v1.13.3
       --ds-color-warning-text-subtle: #80540f;
       --ds-color-warning-icon-subtle: #80540f;
       --ds-color-warning-text-default: #3c2807;
+      --ds-color-warning-icon-default: #3c2807;
       --ds-color-warning-base-default: #ea9b1b;
       --ds-color-warning-base-hover: #cd8818;
       --ds-color-warning-base-active: #b27614;
@@ -395,6 +410,7 @@ design-tokens: v1.13.3
       --ds-color-danger-text-subtle: #b81a1a;
       --ds-color-danger-icon-subtle: #b81a1a;
       --ds-color-danger-text-default: #590d0d;
+      --ds-color-danger-icon-default: #590d0d;
       --ds-color-danger-base-default: #c01b1b;
       --ds-color-danger-base-hover: #9b1616;
       --ds-color-danger-base-active: #791111;
@@ -607,6 +623,7 @@ design-tokens: v1.13.3
     --ds-color-accent-text-subtle: #a5a7b1;
     --ds-color-accent-icon-subtle: #a5a7b1;
     --ds-color-accent-text-default: #ececee;
+    --ds-color-accent-icon-default: #ececee;
     --ds-color-accent-base-default: #a9aab8;
     --ds-color-accent-base-hover: #9395a7;
     --ds-color-accent-base-active: #7e8095;
@@ -624,6 +641,7 @@ design-tokens: v1.13.3
     --ds-color-neutral-text-subtle: #a6a8aa;
     --ds-color-neutral-icon-subtle: #a6a8aa;
     --ds-color-neutral-text-default: #ececed;
+    --ds-color-neutral-icon-default: #ececed;
     --ds-color-neutral-base-default: #a8abae;
     --ds-color-neutral-base-hover: #93979a;
     --ds-color-neutral-base-active: #7d8286;
@@ -641,6 +659,7 @@ design-tokens: v1.13.3
     --ds-color-support1-text-subtle: #aaa0de;
     --ds-color-support1-icon-subtle: #aaa0de;
     --ds-color-support1-text-default: #edebf8;
+    --ds-color-support1-icon-default: #edebf8;
     --ds-color-support1-base-default: #896cee;
     --ds-color-support1-base-hover: #9f87f1;
     --ds-color-support1-base-active: #b3a0f4;
@@ -658,6 +677,7 @@ design-tokens: v1.13.3
     --ds-color-support2-text-subtle: #a8a8a8;
     --ds-color-support2-icon-subtle: #a8a8a8;
     --ds-color-support2-text-default: #ececec;
+    --ds-color-support2-icon-default: #ececec;
     --ds-color-support2-base-default: #000000;
     --ds-color-support2-base-hover: #181818;
     --ds-color-support2-base-active: #282828;
@@ -675,6 +695,7 @@ design-tokens: v1.13.3
     --ds-color-info-text-subtle: #8aabcb;
     --ds-color-info-icon-subtle: #8aabcb;
     --ds-color-info-text-default: #e6edf4;
+    --ds-color-info-icon-default: #e6edf4;
     --ds-color-info-base-default: #2d85c9;
     --ds-color-info-base-hover: #519ad2;
     --ds-color-info-base-active: #77b0dc;
@@ -692,6 +713,7 @@ design-tokens: v1.13.3
     --ds-color-success-text-subtle: #89b289;
     --ds-color-success-icon-subtle: #89b289;
     --ds-color-success-text-default: #e6efe6;
+    --ds-color-success-icon-default: #e6efe6;
     --ds-color-success-base-default: #138d24;
     --ds-color-success-base-hover: #3ca14b;
     --ds-color-success-base-active: #66b571;
@@ -709,6 +731,7 @@ design-tokens: v1.13.3
     --ds-color-warning-text-subtle: #d39e5b;
     --ds-color-warning-icon-subtle: #d39e5b;
     --ds-color-warning-text-default: #f7ebdb;
+    --ds-color-warning-icon-default: #f7ebdb;
     --ds-color-warning-base-default: #60400b;
     --ds-color-warning-base-hover: #7a510e;
     --ds-color-warning-base-active: #946211;
@@ -726,6 +749,7 @@ design-tokens: v1.13.3
     --ds-color-danger-text-subtle: #d19a96;
     --ds-color-danger-icon-subtle: #d19a96;
     --ds-color-danger-text-default: #f5eae9;
+    --ds-color-danger-icon-default: #f5eae9;
     --ds-color-danger-base-default: #d76e6e;
     --ds-color-danger-base-hover: #df8b8b;
     --ds-color-danger-base-active: #e7a8a8;
@@ -752,6 +776,7 @@ design-tokens: v1.13.3
       --ds-color-accent-text-subtle: #a5a7b1;
       --ds-color-accent-icon-subtle: #a5a7b1;
       --ds-color-accent-text-default: #ececee;
+      --ds-color-accent-icon-default: #ececee;
       --ds-color-accent-base-default: #a9aab8;
       --ds-color-accent-base-hover: #9395a7;
       --ds-color-accent-base-active: #7e8095;
@@ -769,6 +794,7 @@ design-tokens: v1.13.3
       --ds-color-neutral-text-subtle: #a6a8aa;
       --ds-color-neutral-icon-subtle: #a6a8aa;
       --ds-color-neutral-text-default: #ececed;
+      --ds-color-neutral-icon-default: #ececed;
       --ds-color-neutral-base-default: #a8abae;
       --ds-color-neutral-base-hover: #93979a;
       --ds-color-neutral-base-active: #7d8286;
@@ -786,6 +812,7 @@ design-tokens: v1.13.3
       --ds-color-support1-text-subtle: #aaa0de;
       --ds-color-support1-icon-subtle: #aaa0de;
       --ds-color-support1-text-default: #edebf8;
+      --ds-color-support1-icon-default: #edebf8;
       --ds-color-support1-base-default: #896cee;
       --ds-color-support1-base-hover: #9f87f1;
       --ds-color-support1-base-active: #b3a0f4;
@@ -803,6 +830,7 @@ design-tokens: v1.13.3
       --ds-color-support2-text-subtle: #a8a8a8;
       --ds-color-support2-icon-subtle: #a8a8a8;
       --ds-color-support2-text-default: #ececec;
+      --ds-color-support2-icon-default: #ececec;
       --ds-color-support2-base-default: #000000;
       --ds-color-support2-base-hover: #181818;
       --ds-color-support2-base-active: #282828;
@@ -820,6 +848,7 @@ design-tokens: v1.13.3
       --ds-color-info-text-subtle: #8aabcb;
       --ds-color-info-icon-subtle: #8aabcb;
       --ds-color-info-text-default: #e6edf4;
+      --ds-color-info-icon-default: #e6edf4;
       --ds-color-info-base-default: #2d85c9;
       --ds-color-info-base-hover: #519ad2;
       --ds-color-info-base-active: #77b0dc;
@@ -837,6 +866,7 @@ design-tokens: v1.13.3
       --ds-color-success-text-subtle: #89b289;
       --ds-color-success-icon-subtle: #89b289;
       --ds-color-success-text-default: #e6efe6;
+      --ds-color-success-icon-default: #e6efe6;
       --ds-color-success-base-default: #138d24;
       --ds-color-success-base-hover: #3ca14b;
       --ds-color-success-base-active: #66b571;
@@ -854,6 +884,7 @@ design-tokens: v1.13.3
       --ds-color-warning-text-subtle: #d39e5b;
       --ds-color-warning-icon-subtle: #d39e5b;
       --ds-color-warning-text-default: #f7ebdb;
+      --ds-color-warning-icon-default: #f7ebdb;
       --ds-color-warning-base-default: #60400b;
       --ds-color-warning-base-hover: #7a510e;
       --ds-color-warning-base-active: #946211;
@@ -871,6 +902,7 @@ design-tokens: v1.13.3
       --ds-color-danger-text-subtle: #d19a96;
       --ds-color-danger-icon-subtle: #d19a96;
       --ds-color-danger-text-default: #f5eae9;
+      --ds-color-danger-icon-default: #f5eae9;
       --ds-color-danger-base-default: #d76e6e;
       --ds-color-danger-base-hover: #df8b8b;
       --ds-color-danger-base-active: #e7a8a8;
@@ -988,6 +1020,7 @@ design-tokens: v1.13.3
     --ds-color-text-subtle: var(--ds-color-accent-text-subtle);
     --ds-color-icon-subtle: var(--ds-color-accent-icon-subtle);
     --ds-color-text-default: var(--ds-color-accent-text-default);
+    --ds-color-icon-default: var(--ds-color-accent-icon-default);
     --ds-color-base-default: var(--ds-color-accent-base-default);
     --ds-color-base-hover: var(--ds-color-accent-base-hover);
     --ds-color-base-active: var(--ds-color-accent-base-active);
@@ -1015,6 +1048,7 @@ design-tokens: v1.13.3
     --ds-color-text-subtle: var(--ds-color-danger-text-subtle);
     --ds-color-icon-subtle: var(--ds-color-danger-icon-subtle);
     --ds-color-text-default: var(--ds-color-danger-text-default);
+    --ds-color-icon-default: var(--ds-color-danger-icon-default);
     --ds-color-base-default: var(--ds-color-danger-base-default);
     --ds-color-base-hover: var(--ds-color-danger-base-hover);
     --ds-color-base-active: var(--ds-color-danger-base-active);
@@ -1042,6 +1076,7 @@ design-tokens: v1.13.3
     --ds-color-text-subtle: var(--ds-color-info-text-subtle);
     --ds-color-icon-subtle: var(--ds-color-info-icon-subtle);
     --ds-color-text-default: var(--ds-color-info-text-default);
+    --ds-color-icon-default: var(--ds-color-info-icon-default);
     --ds-color-base-default: var(--ds-color-info-base-default);
     --ds-color-base-hover: var(--ds-color-info-base-hover);
     --ds-color-base-active: var(--ds-color-info-base-active);
@@ -1067,6 +1102,7 @@ design-tokens: v1.13.3
     --ds-color-text-subtle: var(--ds-color-neutral-text-subtle);
     --ds-color-icon-subtle: var(--ds-color-neutral-icon-subtle);
     --ds-color-text-default: var(--ds-color-neutral-text-default);
+    --ds-color-icon-default: var(--ds-color-neutral-icon-default);
     --ds-color-base-default: var(--ds-color-neutral-base-default);
     --ds-color-base-hover: var(--ds-color-neutral-base-hover);
     --ds-color-base-active: var(--ds-color-neutral-base-active);
@@ -1094,6 +1130,7 @@ design-tokens: v1.13.3
     --ds-color-text-subtle: var(--ds-color-success-text-subtle);
     --ds-color-icon-subtle: var(--ds-color-success-icon-subtle);
     --ds-color-text-default: var(--ds-color-success-text-default);
+    --ds-color-icon-default: var(--ds-color-success-icon-default);
     --ds-color-base-default: var(--ds-color-success-base-default);
     --ds-color-base-hover: var(--ds-color-success-base-hover);
     --ds-color-base-active: var(--ds-color-success-base-active);
@@ -1121,6 +1158,7 @@ design-tokens: v1.13.3
     --ds-color-text-subtle: var(--ds-color-support1-text-subtle);
     --ds-color-icon-subtle: var(--ds-color-support1-icon-subtle);
     --ds-color-text-default: var(--ds-color-support1-text-default);
+    --ds-color-icon-default: var(--ds-color-support1-icon-default);
     --ds-color-base-default: var(--ds-color-support1-base-default);
     --ds-color-base-hover: var(--ds-color-support1-base-hover);
     --ds-color-base-active: var(--ds-color-support1-base-active);
@@ -1148,6 +1186,7 @@ design-tokens: v1.13.3
     --ds-color-text-subtle: var(--ds-color-support2-text-subtle);
     --ds-color-icon-subtle: var(--ds-color-support2-icon-subtle);
     --ds-color-text-default: var(--ds-color-support2-text-default);
+    --ds-color-icon-default: var(--ds-color-support2-icon-default);
     --ds-color-base-default: var(--ds-color-support2-base-default);
     --ds-color-base-hover: var(--ds-color-support2-base-hover);
     --ds-color-base-active: var(--ds-color-support2-base-active);
@@ -1175,6 +1214,7 @@ design-tokens: v1.13.3
     --ds-color-text-subtle: var(--ds-color-warning-text-subtle);
     --ds-color-icon-subtle: var(--ds-color-warning-icon-subtle);
     --ds-color-text-default: var(--ds-color-warning-text-default);
+    --ds-color-icon-default: var(--ds-color-warning-icon-default);
     --ds-color-base-default: var(--ds-color-warning-base-default);
     --ds-color-base-hover: var(--ds-color-warning-base-hover);
     --ds-color-base-active: var(--ds-color-warning-base-active);

--- a/packages/themes/src/themes/minkommune.tailwind.css
+++ b/packages/themes/src/themes/minkommune.tailwind.css
@@ -18,6 +18,7 @@
   --color-accent-border-default: var(--ds-color-accent-border-default);
   --color-accent-border-strong: var(--ds-color-accent-border-strong);
   --color-accent-border-subtle: var(--ds-color-accent-border-subtle);
+  --color-accent-icon-default: var(--ds-color-accent-icon-default);
   --color-accent-icon-subtle: var(--ds-color-accent-icon-subtle);
   --color-accent-surface-active: var(--ds-color-accent-surface-active);
   --color-accent-surface-default: var(--ds-color-accent-surface-default);
@@ -49,6 +50,7 @@
   --color-danger-border-default: var(--ds-color-danger-border-default);
   --color-danger-border-strong: var(--ds-color-danger-border-strong);
   --color-danger-border-subtle: var(--ds-color-danger-border-subtle);
+  --color-danger-icon-default: var(--ds-color-danger-icon-default);
   --color-danger-icon-subtle: var(--ds-color-danger-icon-subtle);
   --color-danger-surface-active: var(--ds-color-danger-surface-active);
   --color-danger-surface-default: var(--ds-color-danger-surface-default);
@@ -56,6 +58,7 @@
   --color-danger-surface-tinted: var(--ds-color-danger-surface-tinted);
   --color-danger-text-default: var(--ds-color-danger-text-default);
   --color-danger-text-subtle: var(--ds-color-danger-text-subtle);
+  --color-icon-default: var(--ds-color-icon-default);
   --color-icon-subtle: var(--ds-color-icon-subtle);
   --color-info-background-default: var(--ds-color-info-background-default);
   --color-info-background-tinted: var(--ds-color-info-background-tinted);
@@ -69,6 +72,7 @@
   --color-info-border-default: var(--ds-color-info-border-default);
   --color-info-border-strong: var(--ds-color-info-border-strong);
   --color-info-border-subtle: var(--ds-color-info-border-subtle);
+  --color-info-icon-default: var(--ds-color-info-icon-default);
   --color-info-icon-subtle: var(--ds-color-info-icon-subtle);
   --color-info-surface-active: var(--ds-color-info-surface-active);
   --color-info-surface-default: var(--ds-color-info-surface-default);
@@ -92,6 +96,7 @@
   --color-neutral-border-default: var(--ds-color-neutral-border-default);
   --color-neutral-border-strong: var(--ds-color-neutral-border-strong);
   --color-neutral-border-subtle: var(--ds-color-neutral-border-subtle);
+  --color-neutral-icon-default: var(--ds-color-neutral-icon-default);
   --color-neutral-icon-subtle: var(--ds-color-neutral-icon-subtle);
   --color-neutral-surface-active: var(--ds-color-neutral-surface-active);
   --color-neutral-surface-default: var(--ds-color-neutral-surface-default);
@@ -115,6 +120,7 @@
   --color-success-border-default: var(--ds-color-success-border-default);
   --color-success-border-strong: var(--ds-color-success-border-strong);
   --color-success-border-subtle: var(--ds-color-success-border-subtle);
+  --color-success-icon-default: var(--ds-color-success-icon-default);
   --color-success-icon-subtle: var(--ds-color-success-icon-subtle);
   --color-success-surface-active: var(--ds-color-success-surface-active);
   --color-success-surface-default: var(--ds-color-success-surface-default);
@@ -140,6 +146,7 @@
   --color-support1-border-default: var(--ds-color-support1-border-default);
   --color-support1-border-strong: var(--ds-color-support1-border-strong);
   --color-support1-border-subtle: var(--ds-color-support1-border-subtle);
+  --color-support1-icon-default: var(--ds-color-support1-icon-default);
   --color-support1-icon-subtle: var(--ds-color-support1-icon-subtle);
   --color-support1-surface-active: var(--ds-color-support1-surface-active);
   --color-support1-surface-default: var(--ds-color-support1-surface-default);
@@ -165,6 +172,7 @@
   --color-support2-border-default: var(--ds-color-support2-border-default);
   --color-support2-border-strong: var(--ds-color-support2-border-strong);
   --color-support2-border-subtle: var(--ds-color-support2-border-subtle);
+  --color-support2-icon-default: var(--ds-color-support2-icon-default);
   --color-support2-icon-subtle: var(--ds-color-support2-icon-subtle);
   --color-support2-surface-active: var(--ds-color-support2-surface-active);
   --color-support2-surface-default: var(--ds-color-support2-surface-default);
@@ -194,6 +202,7 @@
   --color-warning-border-default: var(--ds-color-warning-border-default);
   --color-warning-border-strong: var(--ds-color-warning-border-strong);
   --color-warning-border-subtle: var(--ds-color-warning-border-subtle);
+  --color-warning-icon-default: var(--ds-color-warning-icon-default);
   --color-warning-icon-subtle: var(--ds-color-warning-icon-subtle);
   --color-warning-surface-active: var(--ds-color-warning-surface-active);
   --color-warning-surface-default: var(--ds-color-warning-surface-default);
@@ -238,6 +247,7 @@
   --color-text-subtle: var(--ds-color-text-subtle);
   --color-icon-subtle: var(--ds-color-icon-subtle);
   --color-text-default: var(--ds-color-text-default);
+  --color-icon-default: var(--ds-color-icon-default);
   --color-base-default: var(--ds-color-base-default);
   --color-base-hover: var(--ds-color-base-hover);
   --color-base-active: var(--ds-color-base-active);

--- a/packages/themes/src/themes/tilskudd.css
+++ b/packages/themes/src/themes/tilskudd.css
@@ -131,6 +131,7 @@ design-tokens: v1.13.3
     --ds-color-accent-text-subtle: #595b77;
     --ds-color-accent-icon-subtle: #595b77;
     --ds-color-accent-text-default: #25284c;
+    --ds-color-accent-icon-default: #25284c;
     --ds-color-accent-base-default: #00042e;
     --ds-color-accent-base-hover: #151940;
     --ds-color-accent-base-active: #272a4e;
@@ -148,6 +149,7 @@ design-tokens: v1.13.3
     --ds-color-neutral-text-subtle: #5a5f5a;
     --ds-color-neutral-icon-subtle: #5a5f5a;
     --ds-color-neutral-text-default: #292c29;
+    --ds-color-neutral-icon-default: #292c29;
     --ds-color-neutral-base-default: #4d524d;
     --ds-color-neutral-base-hover: #3b3f3b;
     --ds-color-neutral-base-active: #2b2e2b;
@@ -165,6 +167,7 @@ design-tokens: v1.13.3
     --ds-color-support1-text-subtle: #556055;
     --ds-color-support1-icon-subtle: #556055;
     --ds-color-support1-text-default: #272d27;
+    --ds-color-support1-icon-default: #272d27;
     --ds-color-support1-base-default: #bcd6bc;
     --ds-color-support1-base-hover: #a8bfa8;
     --ds-color-support1-base-active: #94a894;
@@ -182,6 +185,7 @@ design-tokens: v1.13.3
     --ds-color-support2-text-subtle: #0b6a53;
     --ds-color-support2-icon-subtle: #0b6a53;
     --ds-color-support2-text-default: #053227;
+    --ds-color-support2-icon-default: #053227;
     --ds-color-support2-base-default: #0d7a5f;
     --ds-color-support2-base-hover: #0b644e;
     --ds-color-support2-base-active: #084f3d;
@@ -199,6 +203,7 @@ design-tokens: v1.13.3
     --ds-color-info-text-subtle: #7b32ce;
     --ds-color-info-icon-subtle: #7b32ce;
     --ds-color-info-text-default: #3b1567;
+    --ds-color-info-icon-default: #3b1567;
     --ds-color-info-base-default: #7529cc;
     --ds-color-info-base-hover: #5d20a1;
     --ds-color-info-base-active: #451879;
@@ -216,6 +221,7 @@ design-tokens: v1.13.3
     --ds-color-success-text-subtle: #056d13;
     --ds-color-success-icon-subtle: #056d13;
     --ds-color-success-text-default: #023409;
+    --ds-color-success-icon-default: #023409;
     --ds-color-success-base-default: #068718;
     --ds-color-success-base-hover: #057014;
     --ds-color-success-base-active: #045a10;
@@ -233,6 +239,7 @@ design-tokens: v1.13.3
     --ds-color-warning-text-subtle: #80540f;
     --ds-color-warning-icon-subtle: #80540f;
     --ds-color-warning-text-default: #3c2807;
+    --ds-color-warning-icon-default: #3c2807;
     --ds-color-warning-base-default: #ea9b1b;
     --ds-color-warning-base-hover: #cd8818;
     --ds-color-warning-base-active: #b27614;
@@ -250,6 +257,7 @@ design-tokens: v1.13.3
     --ds-color-danger-text-subtle: #b81a1a;
     --ds-color-danger-icon-subtle: #b81a1a;
     --ds-color-danger-text-default: #590d0d;
+    --ds-color-danger-icon-default: #590d0d;
     --ds-color-danger-base-default: #c01b1b;
     --ds-color-danger-base-hover: #9b1616;
     --ds-color-danger-base-active: #791111;
@@ -276,6 +284,7 @@ design-tokens: v1.13.3
       --ds-color-accent-text-subtle: #595b77;
       --ds-color-accent-icon-subtle: #595b77;
       --ds-color-accent-text-default: #25284c;
+      --ds-color-accent-icon-default: #25284c;
       --ds-color-accent-base-default: #00042e;
       --ds-color-accent-base-hover: #151940;
       --ds-color-accent-base-active: #272a4e;
@@ -293,6 +302,7 @@ design-tokens: v1.13.3
       --ds-color-neutral-text-subtle: #5a5f5a;
       --ds-color-neutral-icon-subtle: #5a5f5a;
       --ds-color-neutral-text-default: #292c29;
+      --ds-color-neutral-icon-default: #292c29;
       --ds-color-neutral-base-default: #4d524d;
       --ds-color-neutral-base-hover: #3b3f3b;
       --ds-color-neutral-base-active: #2b2e2b;
@@ -310,6 +320,7 @@ design-tokens: v1.13.3
       --ds-color-support1-text-subtle: #556055;
       --ds-color-support1-icon-subtle: #556055;
       --ds-color-support1-text-default: #272d27;
+      --ds-color-support1-icon-default: #272d27;
       --ds-color-support1-base-default: #bcd6bc;
       --ds-color-support1-base-hover: #a8bfa8;
       --ds-color-support1-base-active: #94a894;
@@ -327,6 +338,7 @@ design-tokens: v1.13.3
       --ds-color-support2-text-subtle: #0b6a53;
       --ds-color-support2-icon-subtle: #0b6a53;
       --ds-color-support2-text-default: #053227;
+      --ds-color-support2-icon-default: #053227;
       --ds-color-support2-base-default: #0d7a5f;
       --ds-color-support2-base-hover: #0b644e;
       --ds-color-support2-base-active: #084f3d;
@@ -344,6 +356,7 @@ design-tokens: v1.13.3
       --ds-color-info-text-subtle: #7b32ce;
       --ds-color-info-icon-subtle: #7b32ce;
       --ds-color-info-text-default: #3b1567;
+      --ds-color-info-icon-default: #3b1567;
       --ds-color-info-base-default: #7529cc;
       --ds-color-info-base-hover: #5d20a1;
       --ds-color-info-base-active: #451879;
@@ -361,6 +374,7 @@ design-tokens: v1.13.3
       --ds-color-success-text-subtle: #056d13;
       --ds-color-success-icon-subtle: #056d13;
       --ds-color-success-text-default: #023409;
+      --ds-color-success-icon-default: #023409;
       --ds-color-success-base-default: #068718;
       --ds-color-success-base-hover: #057014;
       --ds-color-success-base-active: #045a10;
@@ -378,6 +392,7 @@ design-tokens: v1.13.3
       --ds-color-warning-text-subtle: #80540f;
       --ds-color-warning-icon-subtle: #80540f;
       --ds-color-warning-text-default: #3c2807;
+      --ds-color-warning-icon-default: #3c2807;
       --ds-color-warning-base-default: #ea9b1b;
       --ds-color-warning-base-hover: #cd8818;
       --ds-color-warning-base-active: #b27614;
@@ -395,6 +410,7 @@ design-tokens: v1.13.3
       --ds-color-danger-text-subtle: #b81a1a;
       --ds-color-danger-icon-subtle: #b81a1a;
       --ds-color-danger-text-default: #590d0d;
+      --ds-color-danger-icon-default: #590d0d;
       --ds-color-danger-base-default: #c01b1b;
       --ds-color-danger-base-hover: #9b1616;
       --ds-color-danger-base-active: #791111;
@@ -607,6 +623,7 @@ design-tokens: v1.13.3
     --ds-color-accent-text-subtle: #a5a7b1;
     --ds-color-accent-icon-subtle: #a5a7b1;
     --ds-color-accent-text-default: #ececee;
+    --ds-color-accent-icon-default: #ececee;
     --ds-color-accent-base-default: #a9aab8;
     --ds-color-accent-base-hover: #9395a7;
     --ds-color-accent-base-active: #7e8095;
@@ -624,6 +641,7 @@ design-tokens: v1.13.3
     --ds-color-neutral-text-subtle: #a7a8a7;
     --ds-color-neutral-icon-subtle: #a7a8a7;
     --ds-color-neutral-text-default: #ececec;
+    --ds-color-neutral-icon-default: #ececec;
     --ds-color-neutral-base-default: #9ea19e;
     --ds-color-neutral-base-hover: #898c89;
     --ds-color-neutral-base-active: #737773;
@@ -641,6 +659,7 @@ design-tokens: v1.13.3
     --ds-color-support1-text-subtle: #9cac9c;
     --ds-color-support1-icon-subtle: #9cac9c;
     --ds-color-support1-text-default: #e7eee7;
+    --ds-color-support1-icon-default: #e7eee7;
     --ds-color-support1-base-default: #262b26;
     --ds-color-support1-base-hover: #363d36;
     --ds-color-support1-base-active: #465046;
@@ -658,6 +677,7 @@ design-tokens: v1.13.3
     --ds-color-support2-text-subtle: #8dafa4;
     --ds-color-support2-icon-subtle: #8dafa4;
     --ds-color-support2-text-default: #e7eeeb;
+    --ds-color-support2-icon-default: #e7eeeb;
     --ds-color-support2-base-default: #38927b;
     --ds-color-support2-base-hover: #5aa492;
     --ds-color-support2-base-active: #7eb8aa;
@@ -675,6 +695,7 @@ design-tokens: v1.13.3
     --ds-color-info-text-subtle: #b39ed4;
     --ds-color-info-icon-subtle: #b39ed4;
     --ds-color-info-text-default: #efeaf6;
+    --ds-color-info-icon-default: #efeaf6;
     --ds-color-info-base-default: #af83e2;
     --ds-color-info-base-hover: #c19fe8;
     --ds-color-info-base-active: #d2b9ee;
@@ -692,6 +713,7 @@ design-tokens: v1.13.3
     --ds-color-success-text-subtle: #89b289;
     --ds-color-success-icon-subtle: #89b289;
     --ds-color-success-text-default: #e6efe6;
+    --ds-color-success-icon-default: #e6efe6;
     --ds-color-success-base-default: #138d24;
     --ds-color-success-base-hover: #3ca14b;
     --ds-color-success-base-active: #66b571;
@@ -709,6 +731,7 @@ design-tokens: v1.13.3
     --ds-color-warning-text-subtle: #d39e5b;
     --ds-color-warning-icon-subtle: #d39e5b;
     --ds-color-warning-text-default: #f7ebdb;
+    --ds-color-warning-icon-default: #f7ebdb;
     --ds-color-warning-base-default: #60400b;
     --ds-color-warning-base-hover: #7a510e;
     --ds-color-warning-base-active: #946211;
@@ -726,6 +749,7 @@ design-tokens: v1.13.3
     --ds-color-danger-text-subtle: #d19a96;
     --ds-color-danger-icon-subtle: #d19a96;
     --ds-color-danger-text-default: #f5eae9;
+    --ds-color-danger-icon-default: #f5eae9;
     --ds-color-danger-base-default: #d76e6e;
     --ds-color-danger-base-hover: #df8b8b;
     --ds-color-danger-base-active: #e7a8a8;
@@ -752,6 +776,7 @@ design-tokens: v1.13.3
       --ds-color-accent-text-subtle: #a5a7b1;
       --ds-color-accent-icon-subtle: #a5a7b1;
       --ds-color-accent-text-default: #ececee;
+      --ds-color-accent-icon-default: #ececee;
       --ds-color-accent-base-default: #a9aab8;
       --ds-color-accent-base-hover: #9395a7;
       --ds-color-accent-base-active: #7e8095;
@@ -769,6 +794,7 @@ design-tokens: v1.13.3
       --ds-color-neutral-text-subtle: #a7a8a7;
       --ds-color-neutral-icon-subtle: #a7a8a7;
       --ds-color-neutral-text-default: #ececec;
+      --ds-color-neutral-icon-default: #ececec;
       --ds-color-neutral-base-default: #9ea19e;
       --ds-color-neutral-base-hover: #898c89;
       --ds-color-neutral-base-active: #737773;
@@ -786,6 +812,7 @@ design-tokens: v1.13.3
       --ds-color-support1-text-subtle: #9cac9c;
       --ds-color-support1-icon-subtle: #9cac9c;
       --ds-color-support1-text-default: #e7eee7;
+      --ds-color-support1-icon-default: #e7eee7;
       --ds-color-support1-base-default: #262b26;
       --ds-color-support1-base-hover: #363d36;
       --ds-color-support1-base-active: #465046;
@@ -803,6 +830,7 @@ design-tokens: v1.13.3
       --ds-color-support2-text-subtle: #8dafa4;
       --ds-color-support2-icon-subtle: #8dafa4;
       --ds-color-support2-text-default: #e7eeeb;
+      --ds-color-support2-icon-default: #e7eeeb;
       --ds-color-support2-base-default: #38927b;
       --ds-color-support2-base-hover: #5aa492;
       --ds-color-support2-base-active: #7eb8aa;
@@ -820,6 +848,7 @@ design-tokens: v1.13.3
       --ds-color-info-text-subtle: #b39ed4;
       --ds-color-info-icon-subtle: #b39ed4;
       --ds-color-info-text-default: #efeaf6;
+      --ds-color-info-icon-default: #efeaf6;
       --ds-color-info-base-default: #af83e2;
       --ds-color-info-base-hover: #c19fe8;
       --ds-color-info-base-active: #d2b9ee;
@@ -837,6 +866,7 @@ design-tokens: v1.13.3
       --ds-color-success-text-subtle: #89b289;
       --ds-color-success-icon-subtle: #89b289;
       --ds-color-success-text-default: #e6efe6;
+      --ds-color-success-icon-default: #e6efe6;
       --ds-color-success-base-default: #138d24;
       --ds-color-success-base-hover: #3ca14b;
       --ds-color-success-base-active: #66b571;
@@ -854,6 +884,7 @@ design-tokens: v1.13.3
       --ds-color-warning-text-subtle: #d39e5b;
       --ds-color-warning-icon-subtle: #d39e5b;
       --ds-color-warning-text-default: #f7ebdb;
+      --ds-color-warning-icon-default: #f7ebdb;
       --ds-color-warning-base-default: #60400b;
       --ds-color-warning-base-hover: #7a510e;
       --ds-color-warning-base-active: #946211;
@@ -871,6 +902,7 @@ design-tokens: v1.13.3
       --ds-color-danger-text-subtle: #d19a96;
       --ds-color-danger-icon-subtle: #d19a96;
       --ds-color-danger-text-default: #f5eae9;
+      --ds-color-danger-icon-default: #f5eae9;
       --ds-color-danger-base-default: #d76e6e;
       --ds-color-danger-base-hover: #df8b8b;
       --ds-color-danger-base-active: #e7a8a8;
@@ -988,6 +1020,7 @@ design-tokens: v1.13.3
     --ds-color-text-subtle: var(--ds-color-accent-text-subtle);
     --ds-color-icon-subtle: var(--ds-color-accent-icon-subtle);
     --ds-color-text-default: var(--ds-color-accent-text-default);
+    --ds-color-icon-default: var(--ds-color-accent-icon-default);
     --ds-color-base-default: var(--ds-color-accent-base-default);
     --ds-color-base-hover: var(--ds-color-accent-base-hover);
     --ds-color-base-active: var(--ds-color-accent-base-active);
@@ -1015,6 +1048,7 @@ design-tokens: v1.13.3
     --ds-color-text-subtle: var(--ds-color-danger-text-subtle);
     --ds-color-icon-subtle: var(--ds-color-danger-icon-subtle);
     --ds-color-text-default: var(--ds-color-danger-text-default);
+    --ds-color-icon-default: var(--ds-color-danger-icon-default);
     --ds-color-base-default: var(--ds-color-danger-base-default);
     --ds-color-base-hover: var(--ds-color-danger-base-hover);
     --ds-color-base-active: var(--ds-color-danger-base-active);
@@ -1042,6 +1076,7 @@ design-tokens: v1.13.3
     --ds-color-text-subtle: var(--ds-color-info-text-subtle);
     --ds-color-icon-subtle: var(--ds-color-info-icon-subtle);
     --ds-color-text-default: var(--ds-color-info-text-default);
+    --ds-color-icon-default: var(--ds-color-info-icon-default);
     --ds-color-base-default: var(--ds-color-info-base-default);
     --ds-color-base-hover: var(--ds-color-info-base-hover);
     --ds-color-base-active: var(--ds-color-info-base-active);
@@ -1067,6 +1102,7 @@ design-tokens: v1.13.3
     --ds-color-text-subtle: var(--ds-color-neutral-text-subtle);
     --ds-color-icon-subtle: var(--ds-color-neutral-icon-subtle);
     --ds-color-text-default: var(--ds-color-neutral-text-default);
+    --ds-color-icon-default: var(--ds-color-neutral-icon-default);
     --ds-color-base-default: var(--ds-color-neutral-base-default);
     --ds-color-base-hover: var(--ds-color-neutral-base-hover);
     --ds-color-base-active: var(--ds-color-neutral-base-active);
@@ -1094,6 +1130,7 @@ design-tokens: v1.13.3
     --ds-color-text-subtle: var(--ds-color-success-text-subtle);
     --ds-color-icon-subtle: var(--ds-color-success-icon-subtle);
     --ds-color-text-default: var(--ds-color-success-text-default);
+    --ds-color-icon-default: var(--ds-color-success-icon-default);
     --ds-color-base-default: var(--ds-color-success-base-default);
     --ds-color-base-hover: var(--ds-color-success-base-hover);
     --ds-color-base-active: var(--ds-color-success-base-active);
@@ -1121,6 +1158,7 @@ design-tokens: v1.13.3
     --ds-color-text-subtle: var(--ds-color-support1-text-subtle);
     --ds-color-icon-subtle: var(--ds-color-support1-icon-subtle);
     --ds-color-text-default: var(--ds-color-support1-text-default);
+    --ds-color-icon-default: var(--ds-color-support1-icon-default);
     --ds-color-base-default: var(--ds-color-support1-base-default);
     --ds-color-base-hover: var(--ds-color-support1-base-hover);
     --ds-color-base-active: var(--ds-color-support1-base-active);
@@ -1148,6 +1186,7 @@ design-tokens: v1.13.3
     --ds-color-text-subtle: var(--ds-color-support2-text-subtle);
     --ds-color-icon-subtle: var(--ds-color-support2-icon-subtle);
     --ds-color-text-default: var(--ds-color-support2-text-default);
+    --ds-color-icon-default: var(--ds-color-support2-icon-default);
     --ds-color-base-default: var(--ds-color-support2-base-default);
     --ds-color-base-hover: var(--ds-color-support2-base-hover);
     --ds-color-base-active: var(--ds-color-support2-base-active);
@@ -1175,6 +1214,7 @@ design-tokens: v1.13.3
     --ds-color-text-subtle: var(--ds-color-warning-text-subtle);
     --ds-color-icon-subtle: var(--ds-color-warning-icon-subtle);
     --ds-color-text-default: var(--ds-color-warning-text-default);
+    --ds-color-icon-default: var(--ds-color-warning-icon-default);
     --ds-color-base-default: var(--ds-color-warning-base-default);
     --ds-color-base-hover: var(--ds-color-warning-base-hover);
     --ds-color-base-active: var(--ds-color-warning-base-active);

--- a/packages/themes/src/themes/tilskudd.tailwind.css
+++ b/packages/themes/src/themes/tilskudd.tailwind.css
@@ -18,6 +18,7 @@
   --color-accent-border-default: var(--ds-color-accent-border-default);
   --color-accent-border-strong: var(--ds-color-accent-border-strong);
   --color-accent-border-subtle: var(--ds-color-accent-border-subtle);
+  --color-accent-icon-default: var(--ds-color-accent-icon-default);
   --color-accent-icon-subtle: var(--ds-color-accent-icon-subtle);
   --color-accent-surface-active: var(--ds-color-accent-surface-active);
   --color-accent-surface-default: var(--ds-color-accent-surface-default);
@@ -49,6 +50,7 @@
   --color-danger-border-default: var(--ds-color-danger-border-default);
   --color-danger-border-strong: var(--ds-color-danger-border-strong);
   --color-danger-border-subtle: var(--ds-color-danger-border-subtle);
+  --color-danger-icon-default: var(--ds-color-danger-icon-default);
   --color-danger-icon-subtle: var(--ds-color-danger-icon-subtle);
   --color-danger-surface-active: var(--ds-color-danger-surface-active);
   --color-danger-surface-default: var(--ds-color-danger-surface-default);
@@ -56,6 +58,7 @@
   --color-danger-surface-tinted: var(--ds-color-danger-surface-tinted);
   --color-danger-text-default: var(--ds-color-danger-text-default);
   --color-danger-text-subtle: var(--ds-color-danger-text-subtle);
+  --color-icon-default: var(--ds-color-icon-default);
   --color-icon-subtle: var(--ds-color-icon-subtle);
   --color-info-background-default: var(--ds-color-info-background-default);
   --color-info-background-tinted: var(--ds-color-info-background-tinted);
@@ -69,6 +72,7 @@
   --color-info-border-default: var(--ds-color-info-border-default);
   --color-info-border-strong: var(--ds-color-info-border-strong);
   --color-info-border-subtle: var(--ds-color-info-border-subtle);
+  --color-info-icon-default: var(--ds-color-info-icon-default);
   --color-info-icon-subtle: var(--ds-color-info-icon-subtle);
   --color-info-surface-active: var(--ds-color-info-surface-active);
   --color-info-surface-default: var(--ds-color-info-surface-default);
@@ -92,6 +96,7 @@
   --color-neutral-border-default: var(--ds-color-neutral-border-default);
   --color-neutral-border-strong: var(--ds-color-neutral-border-strong);
   --color-neutral-border-subtle: var(--ds-color-neutral-border-subtle);
+  --color-neutral-icon-default: var(--ds-color-neutral-icon-default);
   --color-neutral-icon-subtle: var(--ds-color-neutral-icon-subtle);
   --color-neutral-surface-active: var(--ds-color-neutral-surface-active);
   --color-neutral-surface-default: var(--ds-color-neutral-surface-default);
@@ -115,6 +120,7 @@
   --color-success-border-default: var(--ds-color-success-border-default);
   --color-success-border-strong: var(--ds-color-success-border-strong);
   --color-success-border-subtle: var(--ds-color-success-border-subtle);
+  --color-success-icon-default: var(--ds-color-success-icon-default);
   --color-success-icon-subtle: var(--ds-color-success-icon-subtle);
   --color-success-surface-active: var(--ds-color-success-surface-active);
   --color-success-surface-default: var(--ds-color-success-surface-default);
@@ -140,6 +146,7 @@
   --color-support1-border-default: var(--ds-color-support1-border-default);
   --color-support1-border-strong: var(--ds-color-support1-border-strong);
   --color-support1-border-subtle: var(--ds-color-support1-border-subtle);
+  --color-support1-icon-default: var(--ds-color-support1-icon-default);
   --color-support1-icon-subtle: var(--ds-color-support1-icon-subtle);
   --color-support1-surface-active: var(--ds-color-support1-surface-active);
   --color-support1-surface-default: var(--ds-color-support1-surface-default);
@@ -165,6 +172,7 @@
   --color-support2-border-default: var(--ds-color-support2-border-default);
   --color-support2-border-strong: var(--ds-color-support2-border-strong);
   --color-support2-border-subtle: var(--ds-color-support2-border-subtle);
+  --color-support2-icon-default: var(--ds-color-support2-icon-default);
   --color-support2-icon-subtle: var(--ds-color-support2-icon-subtle);
   --color-support2-surface-active: var(--ds-color-support2-surface-active);
   --color-support2-surface-default: var(--ds-color-support2-surface-default);
@@ -194,6 +202,7 @@
   --color-warning-border-default: var(--ds-color-warning-border-default);
   --color-warning-border-strong: var(--ds-color-warning-border-strong);
   --color-warning-border-subtle: var(--ds-color-warning-border-subtle);
+  --color-warning-icon-default: var(--ds-color-warning-icon-default);
   --color-warning-icon-subtle: var(--ds-color-warning-icon-subtle);
   --color-warning-surface-active: var(--ds-color-warning-surface-active);
   --color-warning-surface-default: var(--ds-color-warning-surface-default);
@@ -238,6 +247,7 @@
   --color-text-subtle: var(--ds-color-text-subtle);
   --color-icon-subtle: var(--ds-color-icon-subtle);
   --color-text-default: var(--ds-color-text-default);
+  --color-icon-default: var(--ds-color-icon-default);
   --color-base-default: var(--ds-color-base-default);
   --color-base-hover: var(--ds-color-base-hover);
   --color-base-active: var(--ds-color-base-active);

--- a/tools/apply-custom-tokens.mjs
+++ b/tools/apply-custom-tokens.mjs
@@ -16,6 +16,7 @@
 // Supported key -> Our alias
 const aliasMap = {
   'text-subtle': ['icon-subtle'],
+  'text-default': ['icon-default'],
 }
 
 import { readdir, readFile, writeFile } from 'node:fs/promises'


### PR DESCRIPTION
## What is the current behavior?

## What is the new behavior?
Add alias token `icon-default` -> `text-default` for all themes and colors

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Checklist

- [ ] 📦 I have updated the public API (for example, if a new component was added)
- [ ] 🧪 Tests - I have added or updated tests that cover my changes (if applicable)
- [ ] 📝 Documentation - I have updated relevant documentation, README, or comments (if applicable)
- [ ] 🔗 I have linked all related issues or discussions

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) describes this PR best?
