### PR TITLE
chore: revert pnpm11

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+public-hoist-pattern[]=@angular/*
+public-hoist-pattern[]=@digdir/designsystemet-web

--- a/package.json
+++ b/package.json
@@ -79,8 +79,13 @@
     "vite-plugin-dts": "catalog:typescript",
     "vitest": "4.0.18"
   },
-  "packageManager": "pnpm@11.0.4+sha512.0a397165007a014ed52919a61e5f46c48b9bca88404c303ecaecc63f62def563898d3c6b8a5d5ea5811eb398cfe03ab05da1a5ce963f126d5ead4c02f93b83c3",
+  "packageManager": "pnpm@10.33.0+sha512.10568bb4a6afb58c9eb3630da90cc9516417abebd3fabbe6739f0ae795728da1491e9db5a544c76ad8eb7570f5c4bb3d6c637b2cb41bfdcdb47fa823c8649319",
   "engines": {
     "node": "24.13.0"
+  },
+  "pnpm": {
+    "overrides": {
+      "vite": "catalog:typescript"
+    }
   }
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -103,11 +103,18 @@ catalogs:
     vitest-axe: '^0.1.0'
 cleanupUnusedCatalogs: true
 minimumReleaseAge: 2880
-overrides:
-  vite: catalog:typescript
-publicHoistPattern:
-  - '@angular/*'
-  - '@digdir/designsystemet-web'
+ignoredBuiltDependencies:
+  - 'less'
+onlyBuiltDependencies:
+  - '@parcel/watcher'
+  - '@swc/core'
+  - 'esbuild'
+  - 'lmdb'
+  - 'msgpackr-extract'
+  - 'msw'
+  - 'nx'
+  - 'sharp'
+  - 'unrs-resolver'
 trustPolicy: 'no-downgrade'
 trustPolicyExclude:
   - 'chokidar@4.0.3'


### PR DESCRIPTION
This reverts commit 2b2b1d4a469b2c60c2f5b5ae2ece88fa3e9a53cb.

## What is the current behavior?
pnpm11 + nx release didnt play along

## What is the new behavior?
go back to v10

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Checklist

- [ ] 📦 I have updated the public API (for example, if a new component was added)
- [ ] 🧪 Tests - I have added or updated tests that cover my changes (if applicable)
- [ ] 📝 Documentation - I have updated relevant documentation, README, or comments (if applicable)
- [ ] 🔗 I have linked all related issues or discussions

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) describes this PR best?
