### PR TITLE
fix(themes): tweak tilskudd-theme border-radius

### DIFF
--- a/design-tokens/themes/tilskudd.json
+++ b/design-tokens/themes/tilskudd.json
@@ -590,7 +590,7 @@
     },
     "base": {
       "$type": "dimension",
-      "$value": "16"
+      "$value": "8"
     },
     "scale": {
       "$type": "dimension",

--- a/designsystemet.config.json
+++ b/designsystemet.config.json
@@ -47,7 +47,7 @@
         },
         "neutral": "#1D252D"
       },
-      "borderRadius": 16
+      "borderRadius": 8
     }
   }
 }

--- a/packages/themes/src/themes/tilskudd.css
+++ b/packages/themes/src/themes/tilskudd.css
@@ -569,7 +569,7 @@ design-tokens: v1.14.0
 
 @layer ds.theme.semantic {
   :root {
-    --ds-border-radius-base: 1rem;
+    --ds-border-radius-base: 0.5rem;
     --ds-border-radius-scale: 0.25rem;
     --ds-border-radius-sm: min(
       var(--ds-border-radius-base) * 0.5,


### PR DESCRIPTION
## What is the current behavior?

## What is the new behavior?
Tweak border-radius for tilskudd theme from designer

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Checklist

- [ ] 📦 I have updated the public API (for example, if a new component was added)
- [ ] 🧪 Tests - I have added or updated tests that cover my changes (if applicable)
- [ ] 📝 Documentation - I have updated relevant documentation, README, or comments (if applicable)
- [ ] 🔗 I have linked all related issues or discussions

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) describes this PR best?
