### PR TITLE
fix(angular/button): dont set button type

### DIFF
--- a/packages/angular/button/src/button.ts
+++ b/packages/angular/button/src/button.ts
@@ -26,7 +26,6 @@ import { Spinner } from '@ks-digital/designsystem-angular/spinner'
   imports: [Spinner],
   host: {
     class: 'ds-button',
-    type: 'button',
     '[attr.data-variant]': 'variant()',
     '[attr.data-icon]': 'icon() || dataIcon() || null',
     '[attr.disabled]': 'disabled() ? true : null',


### PR DESCRIPTION
## What is the current behavior?
Button directive sets type="button" which it shouldnt do
## What is the new behavior?
Button directive does not set type="button"

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

## Checklist

- [ ] 📦 I have updated the public API (for example, if a new component was added)
- [ ] 🧪 Tests - I have added or updated tests that cover my changes (if applicable)
- [ ] 📝 Documentation - I have updated relevant documentation, README, or comments (if applicable)
- [ ] 🔗 I have linked all related issues or discussions

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) describes this PR best?
