### PR TITLE
docs(angular): update link stories

### DIFF
--- a/packages/angular/link/src/link.mdx
+++ b/packages/angular/link/src/link.mdx
@@ -39,11 +39,7 @@ import * as LinkStories from './link.stories'
 
 <Canvas of={LinkStories.WithIconRight} />
 
-### Med flere ikoner
-
-<Canvas of={LinkStories.WithMultipleIcons} />
-
-### Med SVG elementer
+### Med SVG ikon
 
 <Canvas of={LinkStories.WithSVG} />
 

--- a/packages/angular/link/src/link.stories.ts
+++ b/packages/angular/link/src/link.stories.ts
@@ -71,7 +71,7 @@ export const WithIconRight: Story = {
     template: `
       <a ksd-link href="https://example.com" ${argsToTemplate(args)}>
         <span>Example Link</span>
-        <ng-icon name="phosphorArrowUpRight" />
+        <ng-icon name="phosphorPencilLine" />
       </a>
     `,
   }),
@@ -85,7 +85,7 @@ export const WithMultipleIcons: Story = {
       <a ksd-link href="https://example.com" ${argsToTemplate(args)}>
         <ng-icon name="phosphorPencilLine" />
         <span>Example Link</span>
-        <ng-icon name="phosphorArrowUpRight" />
+        <ng-icon name="phosphorPencilLine" />
       </a>
     `,
   }),
@@ -97,7 +97,7 @@ export const WithOnlyIcons: Story = {
     props: args,
     template: `
       <a ksd-link href="https://example.com" ${argsToTemplate(args)} aria-label="Example Link">
-        <ng-icon name="phosphorArrowUpRight" />
+        <ng-icon name="phosphorPencilLine" />
       </a>
     `,
   }),

--- a/packages/angular/link/src/link.stories.ts
+++ b/packages/angular/link/src/link.stories.ts
@@ -1,6 +1,7 @@
 import { NgIcon, provideIcons } from '@ng-icons/core'
 import {
-  phosphorArrowUpRight,
+  phosphorDownloadSimple,
+  phosphorFilePdf,
   phosphorPencilLine,
 } from '@ng-icons/phosphor-icons/regular'
 import { argsToTemplate, Meta, moduleMetadata } from '@storybook/angular'
@@ -18,7 +19,13 @@ const meta: Meta<LinkArgs> = {
   decorators: [
     moduleMetadata({
       imports: [Link, NgIcon],
-      providers: [provideIcons({ phosphorPencilLine, phosphorArrowUpRight })],
+      providers: [
+        provideIcons({
+          phosphorPencilLine,
+          phosphorFilePdf,
+          phosphorDownloadSimple,
+        }),
+      ],
     }),
   ],
 }
@@ -58,7 +65,7 @@ export const WithIcon: Story = {
     template: `
       <a ksd-link href="https://example.com" ${argsToTemplate(args)}>
         <ng-icon name="phosphorPencilLine" />
-        <span>Example Link</span>
+        Endre
       </a>
     `,
   }),
@@ -69,23 +76,16 @@ export const WithIconRight: Story = {
   render: (args) => ({
     props: args,
     template: `
-      <a ksd-link href="https://example.com" ${argsToTemplate(args)}>
-        <span>Example Link</span>
-        <ng-icon name="phosphorPencilLine" />
-      </a>
-    `,
-  }),
-}
+      <a
+        ksd-link
+        href="https://example.com/docs"
+        target="_blank"
+        rel="noopener noreferrer"
+        ${argsToTemplate(args)}
+      >
 
-export const WithMultipleIcons: Story = {
-  args: {},
-  render: (args) => ({
-    props: args,
-    template: `
-      <a ksd-link href="https://example.com" ${argsToTemplate(args)}>
-        <ng-icon name="phosphorPencilLine" />
-        <span>Example Link</span>
-        <ng-icon name="phosphorPencilLine" />
+        Last ned årsrapport (PDF, 2.4 MB)
+        <ng-icon name="phosphorFilePdf" aria-hidden="true" />
       </a>
     `,
   }),
@@ -110,8 +110,7 @@ export const WithSVG: Story = {
     template: `
       <a ksd-link href="https://example.com" ${argsToTemplate(args)}>
         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" fill="currentColor"><path d="M227.32,73.37,182.63,28.69a16,16,0,0,0-22.63,0L36.69,152A15.86,15.86,0,0,0,32,163.31V208a16,16,0,0,0,16,16H216a8,8,0,0,0,0-16H115.32l112-112A16,16,0,0,0,227.32,73.37ZM136,75.31,152.69,92,68,176.69,51.31,160ZM48,208V179.31L76.69,208Zm48-3.31L79.32,188,164,103.31,180.69,120Zm96-96L147.32,64l24-24L216,84.69Z"></path></svg>
-        <span>Tekst</span>
-        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" fill="currentColor"><path d="M200,64V168a8,8,0,0,1-16,0V83.31L69.66,197.66a8,8,0,0,1-11.32-11.32L172.69,72H88a8,8,0,0,1,0-16H192A8,8,0,0,1,200,64Z"></path></svg>
+        Endre
       </a>
     `,
   }),


### PR DESCRIPTION
## What is the current behavior?
Link example with arrow-icon is misleading since [we are not recommending icons for external links](https://designsystemet.no/no/components/docs/link/overview#ikke-bruk-ikon-for-ekstern-lenke)

## What is the new behavior?
Use pencil icon as example

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Checklist

- [ ] 📦 I have updated the public API (for example, if a new component was added)
- [ ] 🧪 Tests - I have added or updated tests that cover my changes (if applicable)
- [ ] 📝 Documentation - I have updated relevant documentation, README, or comments (if applicable)
- [ ] 🔗 I have linked all related issues or discussions

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) describes this PR best?
