### PR TITLE
fix(angular/suggestion): refactor DOM to match expected web-component-structure in  order to fix position recalculation

### DIFF
--- a/packages/angular/suggestion/src/suggestion-list.ts
+++ b/packages/angular/suggestion/src/suggestion-list.ts
@@ -1,4 +1,3 @@
-import { NgTemplateOutlet } from '@angular/common'
 import {
   ChangeDetectionStrategy,
   Component,
@@ -14,28 +13,10 @@ import { SuggestionListOption } from './suggestion-list-option'
   selector: 'ksd-suggestion-list',
   changeDetection: ChangeDetectionStrategy.OnPush,
   schemas: [CUSTOM_ELEMENTS_SCHEMA],
-  imports: [NgTemplateOutlet],
   host: {
-    style: 'display: contents;',
+    style: 'display: none;',
   },
-  template: `
-    <u-datalist
-      data-nofilter
-      [attr.data-sr-singular]="singular()"
-      [attr.data-sr-plural]="plural()"
-    >
-      @for (option of options(); track option) {
-        <u-option [value]="option.value()">
-          <ng-container *ngTemplateOutlet="option.templateRef()" />
-        </u-option>
-      }
-      @if (empty()?.templateRef()) {
-        <u-option data-empty value="" hidden>
-          <ng-container *ngTemplateOutlet="empty()?.templateRef()" />
-        </u-option>
-      }
-    </u-datalist>
-  `,
+  template: ``,
 })
 export class SuggestionList {
   /**
@@ -56,5 +37,5 @@ export class SuggestionList {
     descendants: true,
   })
 
-  protected readonly empty = contentChild(SuggestionListEmpty)
+  readonly empty = contentChild(SuggestionListEmpty)
 }

--- a/packages/angular/suggestion/src/suggestion.spec.ts
+++ b/packages/angular/suggestion/src/suggestion.spec.ts
@@ -356,4 +356,17 @@ describe('Suggestion', () => {
       })
     })
   })
+
+  describe('u-datalist popover', () => {
+    it('should render u-datalist as a direct child of ds-suggestion with popover="manual" and data-is-floating', async () => {
+      const { container } = await renderSuggestionWithList()
+
+      const dsSuggestion = container.querySelector('ds-suggestion')
+      const datalist = dsSuggestion?.querySelector(':scope > u-datalist')
+
+      expect(datalist).toBeInTheDocument()
+      expect(datalist).toHaveAttribute('popover', 'manual')
+      expect(datalist).toHaveAttribute('data-is-floating', 'true')
+    })
+  })
 })

--- a/packages/angular/suggestion/src/suggestion.ts
+++ b/packages/angular/suggestion/src/suggestion.ts
@@ -1,3 +1,4 @@
+import { NgTemplateOutlet } from '@angular/common'
 import {
   afterNextRender,
   booleanAttribute,
@@ -42,6 +43,7 @@ const defaultFilter = ({ label, input }: SuggestionFilterArgs) =>
     },
   ],
   schemas: [CUSTOM_ELEMENTS_SCHEMA],
+  imports: [NgTemplateOutlet],
   host: {},
   template: `
     <ds-suggestion
@@ -57,6 +59,24 @@ const defaultFilter = ({ label, input }: SuggestionFilterArgs) =>
         <data [attr.value]="option.value">{{ option.label }}</data>
       }
       <ng-content />
+      <u-datalist
+        popover="manual"
+        data-is-floating="true"
+        data-nofilter
+        [attr.data-sr-singular]="suggestionList()?.singular()"
+        [attr.data-sr-plural]="suggestionList()?.plural()"
+      >
+        @for (option of suggestionList()?.options() ?? []; track option) {
+          <u-option [value]="option.value()">
+            <ng-container *ngTemplateOutlet="option.templateRef()" />
+          </u-option>
+        }
+        @if (suggestionList()?.empty()?.templateRef(); as emptyTpl) {
+          <u-option data-empty value="" hidden>
+            <ng-container *ngTemplateOutlet="emptyTpl" />
+          </u-option>
+        }
+      </u-datalist>
     </ds-suggestion>
   `,
 })
@@ -92,7 +112,7 @@ export class Suggestion {
   protected selectedArray = computed(() => sanitizeItems(this.selected()))
   private readonly suggestionElement =
     viewChild<ElementRef<HTMLElement>>('suggestionElement')
-  private readonly suggestionList = contentChild(SuggestionList)
+  protected readonly suggestionList = contentChild(SuggestionList)
 
   constructor() {
     afterNextRender(() => this.syncOptions(null))


### PR DESCRIPTION
## What is the current behavior?
Timing can cause the initial rendering from the web component to not find a matching datalist and therefore not set the required attributes and thus popover position recalculation will sometimes be wrong

## What is the new behavior?
Same DOM structure as designsystemet-web expects makes calculation work regardless of timing

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Checklist

- [ ] 📦 I have updated the public API (for example, if a new component was added)
- [ ] 🧪 Tests - I have added or updated tests that cover my changes (if applicable)
- [ ] 📝 Documentation - I have updated relevant documentation, README, or comments (if applicable)
- [ ] 🔗 I have linked all related issues or discussions

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) describes this PR best?
