### PR TITLE
fix(angular): expand ksd-error selector

### DIFF
--- a/packages/angular/forms/src/field/field-error.ts
+++ b/packages/angular/forms/src/field/field-error.ts
@@ -2,7 +2,7 @@ import { ChangeDetectionStrategy, Component } from '@angular/core'
 import { ValidationMessage } from '@ks-digital/designsystem-angular/validation-message'
 
 @Component({
-  selector: '[ksd-error]',
+  selector: 'ksd-error, [ksd-error]',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `<ng-content />`,
   hostDirectives: [

--- a/packages/angular/forms/src/field/field.spec.ts
+++ b/packages/angular/forms/src/field/field.spec.ts
@@ -4,6 +4,7 @@ import { Input } from '../input'
 import { Label } from '../label'
 import { Field } from './field'
 import { FieldDescription } from './field-description'
+import { FieldError } from './field-error'
 
 test('should connect checkbox and label', async () => {
   await render(
@@ -34,6 +35,20 @@ test('should forward data-variant to ds-field', async () => {
   const dsField = container.querySelector('ds-field')
 
   expect(dsField).toHaveAttribute('data-variant', 'outline')
+})
+
+test('should support ksd-error element selector', async () => {
+  await render(
+    `
+    <ksd-field>
+      <ksd-label> Check me </ksd-label>
+      <input ksd-input type="checkbox" value="telefon" />
+      <ksd-error>Error message</ksd-error>
+    </ksd-field>`,
+    { imports: [Field, Label, Input, FieldError] },
+  )
+
+  expect(screen.getByText('Error message')).toBeVisible()
 })
 
 describe('should connect checkbox and description', () => {


### PR DESCRIPTION
## What is the current behavior?
`ksd-error` is only available as a directive-selector
## What is the new behavior?
ksd-error is available as a component selector as well


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Checklist

- [ ] 📦 I have updated the public API (for example, if a new component was added)
- [x] 🧪 Tests - I have added or updated tests that cover my changes (if applicable)
- [ ] 📝 Documentation - I have updated relevant documentation, README, or comments (if applicable)
- [ ] 🔗 I have linked all related issues or discussions

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) describes this PR best?
