### PR TITLE
GHA: Oppdater action-kall med wrapper eller ny versjon

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -19,7 +19,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: ks-no/github-actions-public/checkout@main
         with:
           fetch-depth: 0
 
@@ -27,7 +27,7 @@ jobs:
         uses: ./.github/actions/install-packages
 
       - name: Run Chromatic
-        uses: chromaui/action@5c6ec06f45a2117a25f07b1bf2b2f3009233fac8 # v16.3.0
+        uses: chromaui/action@14cfaef73576e69f95f47f60058063f46ca38719 # v18.1.0
         with:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
           exitZeroOnChanges: false

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -19,7 +19,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout repository
-        uses: ks-no/github-actions-public/checkout@main
+        uses: ks-no/github-actions-public/checkout@23507d99e1864f7eedfa91386a280356bbc93b7f # @11. aug 26
         with:
           fetch-depth: 0
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: ks-no/github-actions-public/checkout@main
+        uses: ks-no/github-actions-public/checkout@23507d99e1864f7eedfa91386a280356bbc93b7f # @11. aug 26
         with:
           fetch-depth: 0
 
@@ -64,7 +64,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: ks-no/github-actions-public/checkout@main
+        uses: ks-no/github-actions-public/checkout@23507d99e1864f7eedfa91386a280356bbc93b7f # @11. aug 26
         with:
           fetch-depth: 0
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: ks-no/github-actions-public/checkout@main
         with:
           fetch-depth: 0
 
@@ -64,7 +64,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: ks-no/github-actions-public/checkout@main
         with:
           fetch-depth: 0
 
@@ -72,7 +72,7 @@ jobs:
         uses: ./.github/actions/install-packages
 
       - name: Cache Playwright
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}

--- a/.github/workflows/deploy-storybook.yml
+++ b/.github/workflows/deploy-storybook.yml
@@ -25,7 +25,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout repository
-        uses: ks-no/github-actions-public/checkout@main
+        uses: ks-no/github-actions-public/checkout@23507d99e1864f7eedfa91386a280356bbc93b7f # @11. aug 26
         with:
           fetch-depth: 1
       - name: Install

--- a/.github/workflows/deploy-storybook.yml
+++ b/.github/workflows/deploy-storybook.yml
@@ -25,7 +25,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: ks-no/github-actions-public/checkout@main
         with:
           fetch-depth: 1
       - name: Install

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,7 +17,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
           filter: tree:0


### PR DESCRIPTION
## What is the current behavior?

## What is the new behavior?

As part of cleanup of Github Actions infrastructure, I replaced calls to `actions/checkout` with `ks-no/github-actions-public/checkout`. This is to minimize the number of places where such references must be updated when new versions are published. Additionally, I updated the version of some other action calls.
I did not replace the checkout call in `publish.yml`, this is because I have not included `filter` input in the wrapper.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Checklist

- [ ] 📦 I have updated the public API (for example, if a new component was added)
- [ ] 🧪 Tests - I have added or updated tests that cover my changes (if applicable)
- [ ] 📝 Documentation - I have updated relevant documentation, README, or comments (if applicable)
- [ ] 🔗 I have linked all related issues or discussions

## [optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) describes this PR best?
